### PR TITLE
feat: implement full RubyLLM::Skills gem

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ['3.1', '3.2', '3.3']
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby ${{ matrix.ruby-version }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true
+
+      - name: Run tests
+        run: bundle exec rake test
+
+      - name: Run linter
+        run: bundle exec standardrb --no-fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2025-01-15
+
+### Added
+
+- Initial release with full Agent Skills specification support
+- `Parser` - YAML frontmatter parsing with safe_load
+- `Skill` - Lazy loading for content and resources
+- `Validator` - Agent Skills spec validation rules
+- `FilesystemLoader` - Directory-based skill loading
+- `ZipLoader` - Archive-based skill loading (optional rubyzip dependency)
+- `DatabaseLoader` - Duck-typed record loading (text or binary storage)
+- `CompositeLoader` - Multi-source skill combination
+- `SkillTool` - RubyLLM tool with progressive disclosure via dynamic description
+- `ChatExtensions` - `with_skills()` and `with_skill_loader()` convenience methods
+- Rails integration with Railtie, generator, and rake tasks
+- Comprehensive test suite (142 tests)

--- a/Gemfile
+++ b/Gemfile
@@ -11,3 +11,6 @@ gem "rake", "~> 13.0"
 gem "minitest", "~> 5.16"
 
 gem "standard", "~> 1.3"
+
+# Optional dependencies for specific loaders
+gem "rubyzip", "~> 2.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,93 @@
+PATH
+  remote: .
+  specs:
+    ruby_llm-skills (0.1.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.3)
+    date (3.5.0)
+    erb (6.0.0)
+    io-console (0.8.1)
+    irb (1.15.3)
+      pp (>= 0.6.0)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
+    json (2.18.0)
+    language_server-protocol (3.17.0.5)
+    lint_roller (1.1.0)
+    minitest (5.27.0)
+    parallel (1.27.0)
+    parser (3.3.10.0)
+      ast (~> 2.4.1)
+      racc
+    pp (0.6.3)
+      prettyprint
+    prettyprint (0.2.0)
+    prism (1.7.0)
+    psych (5.2.6)
+      date
+      stringio
+    racc (1.8.1)
+    rainbow (3.1.1)
+    rake (13.3.1)
+    rdoc (6.17.0)
+      erb
+      psych (>= 4.0.0)
+      tsort
+    regexp_parser (2.11.3)
+    reline (0.6.3)
+      io-console (~> 0.5)
+    rubocop (1.81.7)
+      json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.47.1, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.48.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.4)
+    rubocop-performance (1.25.0)
+      lint_roller (~> 1.1)
+      rubocop (>= 1.75.0, < 2.0)
+      rubocop-ast (>= 1.38.0, < 2.0)
+    ruby-progressbar (1.13.0)
+    rubyzip (2.4.1)
+    standard (1.52.0)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.81.7)
+      standard-custom (~> 1.0.0)
+      standard-performance (~> 1.8)
+    standard-custom (1.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.50)
+    standard-performance (1.8.0)
+      lint_roller (~> 1.1)
+      rubocop-performance (~> 1.25.0)
+    stringio (3.1.9)
+    tsort (0.2.0)
+    unicode-display_width (3.2.0)
+      unicode-emoji (~> 4.1)
+    unicode-emoji (4.1.0)
+
+PLATFORMS
+  arm64-darwin-24
+  ruby
+
+DEPENDENCIES
+  irb
+  minitest (~> 5.16)
+  rake (~> 13.0)
+  ruby_llm-skills!
+  rubyzip (~> 2.3)
+  standard (~> 1.3)
+
+BUNDLED WITH
+   2.6.5

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2025 Kieran Klaassen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Agent Skills for [RubyLLM](https://github.com/crmne/ruby_llm). Teach your AI how
 Skills are folders of instructions, scripts, and resources that extend LLM capabilities for specialized tasks. This gem implements the [Agent Skills specification](https://agentskills.io/specification) for RubyLLM.
 
 [![Gem Version](https://badge.fury.io/rb/ruby_llm-skills.svg)](https://badge.fury.io/rb/ruby_llm-skills)
-[![Build Status](https://github.com/patvice/ruby_llm-skills/actions/workflows/build.yml/badge.svg)](https://github.com/patvice/ruby_llm-skills/actions)
+[![CI](https://github.com/kieranklaassen/ruby_llm-skills/actions/workflows/ci.yml/badge.svg)](https://github.com/kieranklaassen/ruby_llm-skills/actions)
 
 ## Installation
 
@@ -370,7 +370,7 @@ description: PDF helper.
 ## Development
 
 ```bash
-git clone https://github.com/patvice/ruby_llm-skills.git
+git clone https://github.com/kieranklaassen/ruby_llm-skills.git
 cd ruby_llm-skills
 bundle install
 bundle exec rake test

--- a/lib/generators/skill/skill_generator.rb
+++ b/lib/generators/skill/skill_generator.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "rails/generators"
+
+class SkillGenerator < Rails::Generators::NamedBase
+  source_root File.expand_path("templates", __dir__)
+
+  class_option :description, type: :string, default: "Description of what this skill does"
+  class_option :license, type: :string, default: nil
+  class_option :scripts, type: :boolean, default: false
+  class_option :references, type: :boolean, default: false
+  class_option :assets, type: :boolean, default: false
+
+  def create_skill_directory
+    empty_directory skill_path
+  end
+
+  def create_skill_md
+    template "SKILL.md.tt", File.join(skill_path, "SKILL.md")
+  end
+
+  def create_scripts_directory
+    return unless options[:scripts]
+
+    empty_directory File.join(skill_path, "scripts")
+    create_file File.join(skill_path, "scripts", ".keep")
+  end
+
+  def create_references_directory
+    return unless options[:references]
+
+    empty_directory File.join(skill_path, "references")
+    create_file File.join(skill_path, "references", ".keep")
+  end
+
+  def create_assets_directory
+    return unless options[:assets]
+
+    empty_directory File.join(skill_path, "assets")
+    create_file File.join(skill_path, "assets", ".keep")
+  end
+
+  private
+
+  def skill_path
+    File.join("app", "skills", skill_name)
+  end
+
+  def skill_name
+    file_name.downcase.tr("_", "-").gsub(/[^a-z0-9-]/, "")
+  end
+
+  def skill_description
+    options[:description]
+  end
+
+  def skill_license
+    options[:license]
+  end
+end

--- a/lib/generators/skill/templates/SKILL.md.tt
+++ b/lib/generators/skill/templates/SKILL.md.tt
@@ -1,0 +1,21 @@
+---
+name: <%= skill_name %>
+description: <%= skill_description %>
+<% if skill_license -%>
+license: <%= skill_license %>
+<% end -%>
+---
+
+# <%= skill_name.split("-").map(&:capitalize).join(" ") %>
+
+Instructions for using this skill.
+
+## When to Use
+
+Use this skill when...
+
+## Steps
+
+1. First step
+2. Second step
+3. Third step

--- a/lib/ruby_llm/skills.rb
+++ b/lib/ruby_llm/skills.rb
@@ -1,10 +1,89 @@
 # frozen_string_literal: true
 
 require_relative "skills/version"
+require_relative "skills/error"
+require_relative "skills/parser"
+require_relative "skills/validator"
+require_relative "skills/skill"
+require_relative "skills/loader"
+require_relative "skills/filesystem_loader"
+require_relative "skills/composite_loader"
+require_relative "skills/skill_tool"
+require_relative "skills/chat_extensions"
+
+# Load Rails integration when Rails is available
+require_relative "skills/railtie" if defined?(Rails::Railtie)
 
 module RubyLlm
   module Skills
-    class Error < StandardError; end
-    # Your code goes here...
+    class << self
+      attr_accessor :default_path, :logger
+
+      # Load skills from a filesystem directory.
+      #
+      # @param path [String] path to skills directory (defaults to default_path)
+      # @return [FilesystemLoader] loader for the directory
+      # @example
+      #   RubyLlm::Skills.from_directory("app/skills")
+      def from_directory(path = default_path)
+        FilesystemLoader.new(path)
+      end
+
+      # Load a single skill from a directory.
+      #
+      # @param path [String] path to skill directory (containing SKILL.md)
+      # @return [Skill] the loaded skill
+      # @raise [LoadError] if SKILL.md not found
+      # @example
+      #   RubyLlm::Skills.load("app/skills/my-skill")
+      def load(path)
+        skill_md = File.join(path, "SKILL.md")
+        raise LoadError, "SKILL.md not found in #{path}" unless File.exist?(skill_md)
+
+        metadata = Parser.parse_file(skill_md)
+        Skill.new(path: path, metadata: metadata)
+      end
+
+      # Load skills from a zip archive.
+      #
+      # @param path [String] path to .zip file
+      # @return [ZipLoader] loader for the archive
+      # @raise [LoadError] if rubyzip not available
+      # @example
+      #   RubyLlm::Skills.from_zip("skills.zip")
+      def from_zip(path)
+        require_relative "skills/zip_loader"
+        ZipLoader.new(path)
+      rescue ::LoadError
+        raise LoadError, "rubyzip gem required for zip support. Add 'gem \"rubyzip\"' to your Gemfile."
+      end
+
+      # Load skills from database records.
+      #
+      # @param records [ActiveRecord::Relation, Array] collection of skill records
+      # @return [DatabaseLoader] loader for the records
+      # @example
+      #   RubyLlm::Skills.from_database(Skill.where(active: true))
+      def from_database(records)
+        require_relative "skills/database_loader"
+        DatabaseLoader.new(records)
+      end
+
+      # Create a composite loader from multiple sources.
+      #
+      # @param loaders [Array<Loader>] loaders to combine
+      # @return [CompositeLoader] combined loader
+      # @example
+      #   RubyLlm::Skills.compose(
+      #     RubyLlm::Skills.from_directory("app/skills"),
+      #     RubyLlm::Skills.from_database(Skill.all)
+      #   )
+      def compose(*loaders)
+        require_relative "skills/composite_loader"
+        CompositeLoader.new(loaders)
+      end
+    end
+
+    self.default_path = "app/skills"
   end
 end

--- a/lib/ruby_llm/skills/chat_extensions.rb
+++ b/lib/ruby_llm/skills/chat_extensions.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module RubyLlm
+  module Skills
+    # Extensions for RubyLLM::Chat to enable skill integration.
+    #
+    # These methods are added to RubyLLM::Chat when ruby_llm-skills is loaded,
+    # providing a convenient API for adding skills to conversations.
+    #
+    # @example
+    #   chat = RubyLlm.chat
+    #   chat.with_skills("app/skills")
+    #   chat.ask("Generate a PDF report")
+    #
+    module ChatExtensions
+      # Add skills from a directory to this chat.
+      #
+      # @param path [String] path to skills directory
+      # @return [self] for chaining
+      # @example
+      #   chat.with_skills("app/skills")
+      def with_skills(path = RubyLlm::Skills.default_path)
+        loader = RubyLlm::Skills.from_directory(path)
+        skill_tool = RubyLlm::Skills::SkillTool.new(loader)
+        with_tool(skill_tool)
+      end
+
+      # Add skills from a loader to this chat.
+      #
+      # @param loader [Loader] any skill loader
+      # @return [self] for chaining
+      # @example
+      #   loader = RubyLlm::Skills.compose(
+      #     RubyLlm::Skills.from_directory("app/skills"),
+      #     RubyLlm::Skills.from_database(Skill.all)
+      #   )
+      #   chat.with_skill_loader(loader)
+      def with_skill_loader(loader)
+        skill_tool = RubyLlm::Skills::SkillTool.new(loader)
+        with_tool(skill_tool)
+      end
+    end
+  end
+end
+
+# Extend RubyLLM::Chat if available
+if defined?(RubyLlm::Chat)
+  RubyLlm::Chat.include(RubyLlm::Skills::ChatExtensions)
+end

--- a/lib/ruby_llm/skills/composite_loader.rb
+++ b/lib/ruby_llm/skills/composite_loader.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module RubyLlm
+  module Skills
+    # Combines multiple loaders into a single source.
+    #
+    # Skills are searched in order, with earlier loaders taking precedence.
+    # This allows layering skills from multiple sources (filesystem, database, etc).
+    #
+    # @example
+    #   composite = CompositeLoader.new([
+    #     FilesystemLoader.new("app/skills"),
+    #     DatabaseLoader.new(Skill.all)
+    #   ])
+    #   composite.list  # => skills from all loaders
+    #
+    class CompositeLoader < Loader
+      attr_reader :loaders
+
+      # Initialize with an array of loaders.
+      #
+      # @param loaders [Array<Loader>] loaders to combine
+      def initialize(loaders)
+        super()
+        @loaders = loaders
+      end
+
+      # List all skills from all loaders.
+      # Skills are deduplicated by name, with earlier loaders taking precedence.
+      #
+      # @return [Array<Skill>] combined list of skills
+      def list
+        skills
+      end
+
+      # Reload all loaders.
+      #
+      # @return [self]
+      def reload!
+        @loaders.each(&:reload!)
+        super
+      end
+
+      protected
+
+      def load_all
+        seen = {}
+        @loaders.flat_map(&:list).each_with_object([]) do |skill, result|
+          next if seen[skill.name]
+
+          seen[skill.name] = true
+          result << skill
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_llm/skills/database_loader.rb
+++ b/lib/ruby_llm/skills/database_loader.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+module RubyLlm
+  module Skills
+    # Loads skills from database records using duck-typing.
+    #
+    # Records must respond to either:
+    # - Text storage: #name, #description, #content
+    # - Binary storage: #name, #description, #data (zip blob)
+    #
+    # Optional methods: #license, #compatibility, #metadata
+    #
+    # @example With text content
+    #   class SkillRecord
+    #     attr_accessor :name, :description, :content
+    #   end
+    #   loader = DatabaseLoader.new(SkillRecord.all)
+    #
+    # @example With ActiveRecord
+    #   loader = DatabaseLoader.new(Skill.where(active: true))
+    #
+    class DatabaseLoader < Loader
+      attr_reader :records
+
+      # Initialize with a collection of records.
+      #
+      # @param records [Enumerable] collection responding to #each
+      def initialize(records)
+        super()
+        @records = records
+      end
+
+      # List all skills from the records.
+      #
+      # @return [Array<Skill>] skills from records
+      def list
+        skills
+      end
+
+      # Reload skills by re-iterating records.
+      # Also reloads the records if they respond to #reload.
+      #
+      # @return [self]
+      def reload!
+        @records.reload if @records.respond_to?(:reload)
+        super
+      end
+
+      protected
+
+      def load_all
+        @records.filter_map do |record|
+          load_skill_from_record(record)
+        rescue => e
+          warn "Warning: Failed to load skill from record: #{e.message}" if RubyLlm::Skills.logger
+          nil
+        end
+      end
+
+      private
+
+      def load_skill_from_record(record)
+        if binary_storage?(record)
+          load_from_binary(record)
+        else
+          load_from_text(record)
+        end
+      end
+
+      def binary_storage?(record)
+        record.respond_to?(:data) && record.data.present?
+      end
+
+      def load_from_text(record)
+        validate_text_record!(record)
+
+        metadata = build_metadata(record)
+        metadata["__content__"] = record.content.to_s
+
+        Skill.new(
+          path: "database:#{record_id(record)}",
+          metadata: metadata
+        )
+      end
+
+      def load_from_binary(record)
+        # Extract skill from zip data
+        require "zip"
+        require "stringio"
+
+        io = StringIO.new(record.data)
+        Zip::File.open_buffer(io) do |zip|
+          skill_md_entry = zip.find_entry("SKILL.md")
+          raise LoadError, "SKILL.md not found in binary data" unless skill_md_entry
+
+          content = skill_md_entry.get_input_stream.read
+          metadata = Parser.parse_string(content)
+          body = Parser.extract_body(content)
+
+          # Override name/description from record if present
+          metadata["name"] = record.name if record.respond_to?(:name) && record.name
+          metadata["description"] = record.description if record.respond_to?(:description) && record.description
+          metadata["__content__"] = body
+
+          Skill.new(
+            path: "database:#{record_id(record)}",
+            metadata: metadata
+          )
+        end
+      rescue ::LoadError
+        raise LoadError, "rubyzip gem required for binary storage. Add 'gem \"rubyzip\"' to your Gemfile."
+      end
+
+      def validate_text_record!(record)
+        raise InvalidSkillError, "Record must respond to #name" unless record.respond_to?(:name)
+        raise InvalidSkillError, "Record must respond to #description" unless record.respond_to?(:description)
+        raise InvalidSkillError, "Record must respond to #content" unless record.respond_to?(:content)
+      end
+
+      def build_metadata(record)
+        metadata = {
+          "name" => record.name.to_s,
+          "description" => record.description.to_s
+        }
+
+        metadata["license"] = record.license.to_s if record.respond_to?(:license) && record.license
+        metadata["compatibility"] = record.compatibility.to_s if record.respond_to?(:compatibility) && record.compatibility
+
+        if record.respond_to?(:skill_metadata) && record.skill_metadata.is_a?(Hash)
+          metadata["metadata"] = record.skill_metadata
+        end
+
+        metadata
+      end
+
+      def record_id(record)
+        if record.respond_to?(:id)
+          record.id
+        elsif record.respond_to?(:name)
+          record.name
+        else
+          record.object_id
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_llm/skills/error.rb
+++ b/lib/ruby_llm/skills/error.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module RubyLlm
+  module Skills
+    # Base error class for all skills-related errors.
+    # Rescue this to catch any error from the gem.
+    class Error < StandardError; end
+
+    # Raised when a skill has invalid structure or content.
+    class InvalidSkillError < Error; end
+
+    # Raised when a requested skill cannot be found.
+    class NotFoundError < Error; end
+
+    # Raised when skill loading fails (filesystem, zip, database).
+    class LoadError < Error; end
+
+    # Raised when YAML frontmatter parsing fails.
+    class ParseError < Error; end
+  end
+end

--- a/lib/ruby_llm/skills/filesystem_loader.rb
+++ b/lib/ruby_llm/skills/filesystem_loader.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module RubyLlm
+  module Skills
+    # Loads skills from a filesystem directory.
+    #
+    # Scans a directory for subdirectories containing SKILL.md files.
+    # Each subdirectory is treated as a skill if it contains a valid SKILL.md.
+    #
+    # @example
+    #   loader = FilesystemLoader.new("app/skills")
+    #   loader.list # => [Skill, Skill, ...]
+    #
+    class FilesystemLoader < Loader
+      attr_reader :path
+
+      # Initialize with a directory path.
+      #
+      # @param path [String, Pathname] path to skills directory
+      def initialize(path)
+        super()
+        @path = path.to_s
+      end
+
+      # List all skills from the directory.
+      #
+      # @return [Array<Skill>] skills found in directory
+      def list
+        skills
+      end
+
+      protected
+
+      def load_all
+        return [] unless File.directory?(@path)
+
+        Dir.glob(File.join(@path, "*", "SKILL.md")).filter_map do |skill_md_path|
+          load_skill(skill_md_path)
+        rescue ParseError => e
+          warn "Warning: Failed to parse #{skill_md_path}: #{e.message}" if RubyLlm::Skills.logger
+          nil
+        end
+      end
+
+      private
+
+      def load_skill(skill_md_path)
+        skill_dir = File.dirname(skill_md_path)
+        metadata = Parser.parse_file(skill_md_path)
+
+        Skill.new(path: skill_dir, metadata: metadata)
+      end
+    end
+  end
+end

--- a/lib/ruby_llm/skills/loader.rb
+++ b/lib/ruby_llm/skills/loader.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module RubyLlm
+  module Skills
+    # Base class for skill loaders.
+    #
+    # Loaders are responsible for discovering and loading skills from various sources:
+    # - FilesystemLoader: loads from directory structures
+    # - ZipLoader: loads from .zip archives
+    # - DatabaseLoader: loads from ActiveRecord models
+    #
+    # @example
+    #   loader = FilesystemLoader.new("app/skills")
+    #   loader.list         # => [skill1, skill2, ...]
+    #   loader.find("name") # => Skill or nil
+    #   loader.get("name")  # => Skill or raises NotFoundError
+    #
+    class Loader
+      # List all skills from this source.
+      #
+      # @return [Array<Skill>] collection of skills
+      def list
+        raise NotImplementedError, "#{self.class}#list must be implemented"
+      end
+
+      # Find a skill by name.
+      #
+      # @param name [String] skill name
+      # @return [Skill, nil] skill or nil if not found
+      def find(name)
+        list.find { |skill| skill.name == name }
+      end
+
+      # Get a skill by name, raising if not found.
+      #
+      # @param name [String] skill name
+      # @return [Skill] the found skill
+      # @raise [NotFoundError] if skill not found
+      def get(name)
+        skill = find(name)
+        raise NotFoundError, "Skill not found: #{name}" unless skill
+
+        skill
+      end
+
+      # Check if a skill exists.
+      #
+      # @param name [String] skill name
+      # @return [Boolean] true if skill exists
+      def exists?(name)
+        !find(name).nil?
+      end
+
+      # Reload all skills, clearing any cache.
+      #
+      # @return [self]
+      def reload!
+        @skills = nil
+        self
+      end
+
+      protected
+
+      # Cache skills from #load_all for performance.
+      def skills
+        @skills ||= load_all
+      end
+
+      # Subclasses must implement this to load all skills.
+      #
+      # @return [Array<Skill>] all skills from source
+      def load_all
+        raise NotImplementedError, "#{self.class}#load_all must be implemented"
+      end
+    end
+  end
+end

--- a/lib/ruby_llm/skills/parser.rb
+++ b/lib/ruby_llm/skills/parser.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "yaml"
+
+module RubyLlm
+  module Skills
+    # Parses SKILL.md files with YAML frontmatter.
+    #
+    # A valid SKILL.md has the format:
+    #   ---
+    #   name: skill-name
+    #   description: What the skill does
+    #   ---
+    #   # Skill content here
+    #
+    class Parser
+      # Regex to match YAML frontmatter between --- delimiters
+      FRONTMATTER_REGEX = /\A---\n(.*?)\n---\n?(.*)/m
+
+      class << self
+        # Parse a SKILL.md file and extract frontmatter metadata.
+        #
+        # @param path [String, Pathname] path to SKILL.md file
+        # @return [Hash] parsed frontmatter as hash
+        # @raise [ParseError] if frontmatter is missing or invalid
+        def parse_file(path)
+          content = File.read(path)
+          parse_string(content)
+        rescue Errno::ENOENT
+          raise ParseError, "File not found: #{path}"
+        rescue Errno::EACCES
+          raise ParseError, "Permission denied: #{path}"
+        end
+
+        # Parse SKILL.md content string and extract frontmatter.
+        #
+        # @param content [String] full SKILL.md content
+        # @return [Hash] parsed frontmatter as hash
+        # @raise [ParseError] if frontmatter is missing or invalid
+        def parse_string(content)
+          match = content.match(FRONTMATTER_REGEX)
+
+          unless match
+            raise ParseError, "Missing YAML frontmatter (must start with ---)"
+          end
+
+          yaml_content = match[1]
+          parse_yaml(yaml_content)
+        end
+
+        # Extract the body content (everything after frontmatter).
+        #
+        # @param content [String] full SKILL.md content
+        # @return [String] body content without frontmatter
+        def extract_body(content)
+          match = content.match(FRONTMATTER_REGEX)
+          return "" unless match
+
+          match[2].to_s.strip
+        end
+
+        private
+
+        def parse_yaml(yaml_content)
+          # Use safe_load with permitted classes for security
+          YAML.safe_load(
+            yaml_content,
+            permitted_classes: [Symbol],
+            permitted_symbols: [],
+            aliases: false
+          ) || {}
+        rescue Psych::SyntaxError => e
+          raise ParseError, "Invalid YAML frontmatter: #{e.message}"
+        rescue Psych::DisallowedClass => e
+          raise ParseError, "Disallowed class in YAML: #{e.message}"
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_llm/skills/railtie.rb
+++ b/lib/ruby_llm/skills/railtie.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module RubyLlm
+  module Skills
+    # Rails integration for RubyLLM::Skills.
+    #
+    # Sets up the default skills path to Rails.root/app/skills
+    # and configures autoloading of skill files.
+    #
+    class Railtie < ::Rails::Railtie
+      initializer "ruby_llm_skills.configure" do
+        RubyLlm::Skills.default_path = Rails.root.join("app", "skills").to_s
+      end
+
+      # Add app/skills to autoload paths
+      initializer "ruby_llm_skills.autoload_paths" do |app|
+        skills_path = Rails.root.join("app", "skills")
+        if skills_path.exist?
+          app.config.autoload_paths << skills_path.to_s
+        end
+      end
+
+      # Provide rake tasks
+      rake_tasks do
+        load File.expand_path("tasks/skills.rake", __dir__)
+      end
+    end
+  end
+end

--- a/lib/ruby_llm/skills/skill.rb
+++ b/lib/ruby_llm/skills/skill.rb
@@ -1,0 +1,174 @@
+# frozen_string_literal: true
+
+module RubyLlm
+  module Skills
+    # Represents a single skill with its metadata and content.
+    #
+    # Skills follow a progressive disclosure pattern:
+    # - Level 1: Metadata (name, description) - loaded immediately
+    # - Level 2: Content (SKILL.md body) - loaded lazily on demand
+    # - Level 3: Resources (scripts, references, assets) - loaded lazily
+    #
+    # @example
+    #   skill = Skill.new(
+    #     path: "app/skills/pdf-report",
+    #     metadata: { "name" => "pdf-report", "description" => "Generate PDFs" }
+    #   )
+    #   skill.name        # => "pdf-report" (immediate)
+    #   skill.content     # => loads SKILL.md body (lazy)
+    #   skill.scripts     # => lists script files (lazy)
+    #
+    class Skill
+      attr_reader :path, :metadata
+
+      # Initialize a skill from parsed metadata.
+      #
+      # @param path [String] path to skill directory or virtual identifier
+      # @param metadata [Hash] parsed YAML frontmatter
+      # @param content [String, nil] pre-loaded content (optional)
+      def initialize(path:, metadata:, content: nil)
+        @path = path.to_s
+        @metadata = metadata || {}
+        @content = content
+      end
+
+      # @return [String] skill name from frontmatter
+      def name
+        @metadata["name"]
+      end
+
+      # @return [String] skill description from frontmatter
+      def description
+        @metadata["description"]
+      end
+
+      # @return [String, nil] license from frontmatter
+      def license
+        @metadata["license"]
+      end
+
+      # @return [String, nil] compatibility info from frontmatter
+      def compatibility
+        @metadata["compatibility"]
+      end
+
+      # @return [Hash] custom metadata key-value pairs
+      def custom_metadata
+        @metadata["metadata"] || {}
+      end
+
+      # @return [Array<String>] list of allowed tools (experimental)
+      def allowed_tools
+        (@metadata["allowed-tools"] || "").split
+      end
+
+      # Get the full SKILL.md content (body without frontmatter).
+      # Content is loaded lazily on first access.
+      #
+      # @return [String] skill instructions
+      def content
+        @content ||= load_content
+      end
+
+      # List script files in the scripts/ directory.
+      # Loaded lazily on first access.
+      #
+      # @return [Array<String>] paths to script files
+      def scripts
+        @scripts ||= list_resources("scripts")
+      end
+
+      # List reference files in the references/ directory.
+      # Loaded lazily on first access.
+      #
+      # @return [Array<String>] paths to reference files
+      def references
+        @references ||= list_resources("references")
+      end
+
+      # List asset files in the assets/ directory.
+      # Loaded lazily on first access.
+      #
+      # @return [Array<String>] paths to asset files
+      def assets
+        @assets ||= list_resources("assets")
+      end
+
+      # Check if skill path is a filesystem path (vs database virtual path).
+      #
+      # @return [Boolean] true if path points to filesystem
+      def filesystem?
+        !virtual?
+      end
+
+      # Check if skill is a virtual/database skill.
+      #
+      # @return [Boolean] true if path is a virtual identifier
+      def virtual?
+        @path.start_with?("database:")
+      end
+
+      # Path to the SKILL.md file.
+      #
+      # @return [String, nil] path to SKILL.md or nil for virtual skills
+      def skill_md_path
+        return nil if virtual?
+
+        File.join(@path, "SKILL.md")
+      end
+
+      # Validate the skill structure.
+      #
+      # @return [Boolean] true if skill is valid
+      def valid?
+        errors.empty?
+      end
+
+      # Get validation errors.
+      #
+      # @return [Array<String>] list of error messages
+      def errors
+        @errors ||= Validator.validate(self)
+      end
+
+      # Clear cached content and resources (useful for testing).
+      def reload!
+        @content = nil
+        @scripts = nil
+        @references = nil
+        @assets = nil
+        @errors = nil
+        self
+      end
+
+      # @return [String] inspection string
+      def inspect
+        "#<#{self.class.name} name=#{name.inspect} path=#{path.inspect}>"
+      end
+
+      private
+
+      def load_content
+        return @metadata["__content__"] if @metadata["__content__"]
+        return "" if virtual?
+
+        md_path = skill_md_path
+        return "" unless md_path && File.exist?(md_path)
+
+        Parser.extract_body(File.read(md_path))
+      end
+
+      def list_resources(subdir)
+        return [] if virtual?
+
+        resource_path = File.join(@path, subdir)
+        return [] unless File.directory?(resource_path)
+
+        Dir.glob(File.join(resource_path, "**", "*"))
+          .select { |f| File.file?(f) }
+          .reject { |f| File.basename(f) == ".keep" }
+          .sort
+      end
+    end
+  end
+end

--- a/lib/ruby_llm/skills/skill_tool.rb
+++ b/lib/ruby_llm/skills/skill_tool.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+module RubyLlm
+  module Skills
+    # A RubyLLM Tool that enables progressive skill loading.
+    #
+    # This tool is the key integration point for LLM skill discovery.
+    # It embeds skill metadata (name + description) in its description,
+    # allowing the LLM to discover available skills. When invoked,
+    # it returns the full skill content.
+    #
+    # Progressive Disclosure Pattern:
+    # 1. Skill metadata is always visible in the tool description (~100 tokens/skill)
+    # 2. Full skill content is loaded on-demand when the tool is called (~5k tokens)
+    # 3. Resources (scripts, references) can be loaded separately as needed
+    #
+    # @example Basic usage
+    #   loader = RubyLlm::Skills.from_directory("app/skills")
+    #   skill_tool = RubyLlm::Skills::SkillTool.new(loader)
+    #
+    #   chat.with_tools(skill_tool)
+    #   chat.ask("Help me generate a PDF report")
+    #   # LLM sees available skills, calls skill_tool with name="pdf-report"
+    #   # Tool returns full SKILL.md content for LLM to follow
+    #
+    class SkillTool
+      attr_reader :loader
+
+      # Initialize with a skill loader.
+      #
+      # @param loader [Loader] any loader (FilesystemLoader, ZipLoader, etc.)
+      def initialize(loader)
+        @loader = loader
+      end
+
+      # Tool name for RubyLLM.
+      #
+      # @return [String] "skill"
+      def name
+        "skill"
+      end
+
+      # Dynamic description including available skills.
+      #
+      # @return [String] tool description with embedded skill metadata
+      def description
+        skills_xml = build_skills_xml
+        <<~DESC.strip
+          Load a skill to get specialized instructions for a task.
+
+          Use this tool when the user's request matches one of the available skills.
+          The tool returns the full skill instructions that you should follow.
+
+          #{skills_xml}
+        DESC
+      end
+
+      # Parameter schema for the tool.
+      #
+      # @return [Hash] JSON Schema for parameters
+      def parameters
+        {
+          type: "object",
+          properties: {
+            skill_name: {
+              type: "string",
+              description: "The name of the skill to load (from the available skills list)"
+            }
+          },
+          required: ["skill_name"]
+        }
+      end
+
+      # Execute the tool to load a skill's content.
+      #
+      # @param skill_name [String] name of skill to load
+      # @return [String] skill content or error message
+      def call(skill_name:)
+        skill = @loader.find(skill_name)
+
+        unless skill
+          available = @loader.list.map(&:name).join(", ")
+          return "Skill '#{skill_name}' not found. Available skills: #{available}"
+        end
+
+        build_skill_response(skill)
+      end
+
+      # Alternative execute method name for RubyLLM compatibility.
+      def execute(skill_name:)
+        call(skill_name: skill_name)
+      end
+
+      # Convert to RubyLLM Tool-compatible format.
+      #
+      # @return [Hash] tool definition for RubyLLM
+      def to_tool_definition
+        {
+          name: name,
+          description: description,
+          parameters: parameters
+        }
+      end
+
+      private
+
+      def build_skills_xml
+        skills = @loader.list
+
+        return "<available_skills>\nNo skills available.\n</available_skills>" if skills.empty?
+
+        xml_parts = ["<available_skills>"]
+
+        skills.each do |skill|
+          xml_parts << "  <skill>"
+          xml_parts << "    <name>#{escape_xml(skill.name)}</name>"
+          xml_parts << "    <description>#{escape_xml(skill.description)}</description>"
+          xml_parts << "  </skill>"
+        end
+
+        xml_parts << "</available_skills>"
+        xml_parts.join("\n")
+      end
+
+      def build_skill_response(skill)
+        parts = []
+        parts << "# Skill: #{skill.name}"
+        parts << ""
+        parts << skill.content
+        parts << ""
+
+        # Include resource information if available
+        if skill.scripts.any?
+          parts << "## Available Scripts"
+          skill.scripts.each { |s| parts << "- #{File.basename(s)}" }
+          parts << ""
+        end
+
+        if skill.references.any?
+          parts << "## Available References"
+          skill.references.each { |r| parts << "- #{File.basename(r)}" }
+          parts << ""
+        end
+
+        if skill.assets.any?
+          parts << "## Available Assets"
+          skill.assets.each { |a| parts << "- #{File.basename(a)}" }
+          parts << ""
+        end
+
+        parts.join("\n").strip
+      end
+
+      def escape_xml(text)
+        return "" if text.nil?
+
+        text.to_s
+          .gsub("&", "&amp;")
+          .gsub("<", "&lt;")
+          .gsub(">", "&gt;")
+          .gsub('"', "&quot;")
+          .gsub("'", "&apos;")
+      end
+    end
+  end
+end

--- a/lib/ruby_llm/skills/tasks/skills.rake
+++ b/lib/ruby_llm/skills/tasks/skills.rake
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+namespace :skills do
+  desc "List all available skills"
+  task list: :environment do
+    loader = RubyLlm::Skills.from_directory
+    skills = loader.list
+
+    if skills.empty?
+      puts "No skills found in #{RubyLlm::Skills.default_path}"
+      next
+    end
+
+    puts "Available skills (#{skills.count}):"
+    puts ""
+
+    skills.each do |skill|
+      status = skill.valid? ? "✓" : "✗"
+      puts "  #{status} #{skill.name}"
+      puts "    #{skill.description}"
+      puts ""
+    end
+  end
+
+  desc "Validate all skills"
+  task validate: :environment do
+    loader = RubyLlm::Skills.from_directory
+    skills = loader.list
+
+    if skills.empty?
+      puts "No skills found in #{RubyLlm::Skills.default_path}"
+      next
+    end
+
+    valid_count = 0
+    invalid_count = 0
+
+    skills.each do |skill|
+      if skill.valid?
+        valid_count += 1
+        puts "✓ #{skill.name}"
+      else
+        invalid_count += 1
+        puts "✗ #{skill.name}"
+        skill.errors.each do |error|
+          puts "    - #{error}"
+        end
+      end
+    end
+
+    puts ""
+    puts "#{valid_count} valid, #{invalid_count} invalid"
+
+    exit(1) if invalid_count > 0
+  end
+
+  desc "Show details of a specific skill"
+  task :show, [:name] => :environment do |_, args|
+    name = args[:name]
+    unless name
+      puts "Usage: rake skills:show[skill-name]"
+      exit(1)
+    end
+
+    loader = RubyLlm::Skills.from_directory
+    skill = loader.find(name)
+
+    unless skill
+      puts "Skill '#{name}' not found"
+      exit(1)
+    end
+
+    puts "Name: #{skill.name}"
+    puts "Description: #{skill.description}"
+    puts "License: #{skill.license || "(none)"}"
+    puts "Compatibility: #{skill.compatibility || "(none)"}"
+    puts "Path: #{skill.path}"
+    puts "Valid: #{skill.valid? ? "yes" : "no"}"
+
+    unless skill.errors.empty?
+      puts ""
+      puts "Errors:"
+      skill.errors.each { |e| puts "  - #{e}" }
+    end
+
+    if skill.custom_metadata.any?
+      puts ""
+      puts "Metadata:"
+      skill.custom_metadata.each { |k, v| puts "  #{k}: #{v}" }
+    end
+
+    if skill.scripts.any?
+      puts ""
+      puts "Scripts:"
+      skill.scripts.each { |s| puts "  - #{File.basename(s)}" }
+    end
+
+    if skill.references.any?
+      puts ""
+      puts "References:"
+      skill.references.each { |r| puts "  - #{File.basename(r)}" }
+    end
+
+    if skill.assets.any?
+      puts ""
+      puts "Assets:"
+      skill.assets.each { |a| puts "  - #{File.basename(a)}" }
+    end
+  end
+end

--- a/lib/ruby_llm/skills/validator.rb
+++ b/lib/ruby_llm/skills/validator.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+module RubyLlm
+  module Skills
+    # Validates skill structure according to the Agent Skills specification.
+    #
+    # Validation rules based on agentskills.io specification:
+    # - name: required, max 64 chars, lowercase + hyphens only, no leading/trailing hyphens
+    # - description: required, max 1024 chars
+    # - license: optional, max 128 chars
+    # - compatibility: optional, max 500 chars
+    #
+    # @example
+    #   errors = Validator.validate(skill)
+    #   puts errors # => [] if valid, or list of error messages
+    #
+    class Validator
+      NAME_MAX_LENGTH = 64
+      DESCRIPTION_MAX_LENGTH = 1024
+      LICENSE_MAX_LENGTH = 128
+      COMPATIBILITY_MAX_LENGTH = 500
+      NAME_PATTERN = /\A[a-z0-9]+(-[a-z0-9]+)*\z/
+
+      class << self
+        # Validate a skill and return all errors.
+        #
+        # @param skill [Skill] skill to validate
+        # @return [Array<String>] list of error messages (empty if valid)
+        def validate(skill)
+          errors = []
+          validate_name(skill, errors)
+          validate_description(skill, errors)
+          validate_license(skill, errors)
+          validate_compatibility(skill, errors)
+          validate_path_name_match(skill, errors)
+          errors
+        end
+
+        # Check if a skill is valid.
+        #
+        # @param skill [Skill] skill to validate
+        # @return [Boolean] true if skill passes validation
+        def valid?(skill)
+          validate(skill).empty?
+        end
+
+        private
+
+        def validate_name(skill, errors)
+          name = skill.name
+
+          if name.nil? || name.empty?
+            errors << "name is required"
+            return
+          end
+
+          if name.length > NAME_MAX_LENGTH
+            errors << "name exceeds maximum length of #{NAME_MAX_LENGTH} characters"
+          end
+
+          unless name.match?(NAME_PATTERN)
+            errors << "name must be lowercase letters, numbers, and single hyphens (no leading/trailing hyphens)"
+          end
+        end
+
+        def validate_description(skill, errors)
+          description = skill.description
+
+          if description.nil? || description.empty?
+            errors << "description is required"
+            return
+          end
+
+          if description.length > DESCRIPTION_MAX_LENGTH
+            errors << "description exceeds maximum length of #{DESCRIPTION_MAX_LENGTH} characters"
+          end
+        end
+
+        def validate_license(skill, errors)
+          license = skill.license
+          return if license.nil? || license.empty?
+
+          if license.length > LICENSE_MAX_LENGTH
+            errors << "license exceeds maximum length of #{LICENSE_MAX_LENGTH} characters"
+          end
+        end
+
+        def validate_compatibility(skill, errors)
+          compatibility = skill.compatibility
+          return if compatibility.nil? || compatibility.empty?
+
+          if compatibility.length > COMPATIBILITY_MAX_LENGTH
+            errors << "compatibility exceeds maximum length of #{COMPATIBILITY_MAX_LENGTH} characters"
+          end
+        end
+
+        def validate_path_name_match(skill, errors)
+          return if skill.virtual?
+
+          dir_name = File.basename(skill.path)
+          return if skill.name == dir_name
+
+          errors << "name '#{skill.name}' does not match directory name '#{dir_name}'"
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_llm/skills/zip_loader.rb
+++ b/lib/ruby_llm/skills/zip_loader.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require "zip"
+
+module RubyLlm
+  module Skills
+    # Loads skills from a ZIP archive.
+    #
+    # The archive should contain skill directories at the root level,
+    # each with a SKILL.md file.
+    #
+    # Structure:
+    #   archive.zip
+    #   ├── skill-one/
+    #   │   ├── SKILL.md
+    #   │   └── scripts/
+    #   └── skill-two/
+    #       └── SKILL.md
+    #
+    # @example
+    #   loader = ZipLoader.new("skills.zip")
+    #   loader.list  # => [Skill, Skill, ...]
+    #
+    class ZipLoader < Loader
+      attr_reader :path
+
+      # Initialize with path to zip file.
+      #
+      # @param path [String] path to .zip archive
+      # @raise [LoadError] if file doesn't exist
+      def initialize(path)
+        super()
+        @path = path.to_s
+        raise LoadError, "Zip file not found: #{@path}" unless File.exist?(@path)
+      end
+
+      # List all skills from the archive.
+      #
+      # @return [Array<Skill>] skills found in archive
+      def list
+        skills
+      end
+
+      # Read content of a file within a skill's directory.
+      #
+      # @param skill_name [String] name of the skill
+      # @param relative_path [String] path relative to skill directory
+      # @return [String, nil] file content or nil if not found
+      def read_file(skill_name, relative_path)
+        entry_path = "#{skill_name}/#{relative_path}"
+        read_zip_entry(entry_path)
+      end
+
+      protected
+
+      def load_all
+        loaded_skills = []
+
+        Zip::File.open(@path) do |zip|
+          skill_dirs = find_skill_directories(zip)
+
+          skill_dirs.each do |skill_dir|
+            skill = load_skill_from_zip(zip, skill_dir)
+            loaded_skills << skill if skill
+          end
+        end
+
+        loaded_skills
+      rescue Zip::Error => e
+        raise LoadError, "Failed to read zip archive: #{e.message}"
+      end
+
+      private
+
+      def find_skill_directories(zip)
+        zip.entries
+          .select { |e| e.name.end_with?("/SKILL.md") }
+          .map { |e| File.dirname(e.name) }
+          .reject { |d| d.include?("/") } # Only top-level skills
+      end
+
+      def load_skill_from_zip(zip, skill_dir)
+        skill_md_path = "#{skill_dir}/SKILL.md"
+        entry = zip.find_entry(skill_md_path)
+        return nil unless entry
+
+        content = entry.get_input_stream.read
+        metadata = Parser.parse_string(content)
+        body = Parser.extract_body(content)
+
+        # Store content in metadata for virtual skill
+        metadata["__content__"] = body
+
+        # Store resource lists
+        metadata["__scripts__"] = list_resources(zip, skill_dir, "scripts")
+        metadata["__references__"] = list_resources(zip, skill_dir, "references")
+        metadata["__assets__"] = list_resources(zip, skill_dir, "assets")
+
+        Skill.new(
+          path: "zip:#{@path}:#{skill_dir}",
+          metadata: metadata
+        )
+      rescue ParseError => e
+        warn "Warning: Failed to parse #{skill_md_path}: #{e.message}" if RubyLlm::Skills.logger
+        nil
+      end
+
+      def list_resources(zip, skill_dir, subdir)
+        prefix = "#{skill_dir}/#{subdir}/"
+        zip.entries
+          .select { |e| e.name.start_with?(prefix) && !e.directory? }
+          .map { |e| e.name.sub(prefix, "") }
+          .reject { |f| f == ".keep" }
+          .sort
+      end
+
+      def read_zip_entry(entry_path)
+        Zip::File.open(@path) do |zip|
+          entry = zip.find_entry(entry_path)
+          return nil unless entry
+
+          entry.get_input_stream.read
+        end
+      rescue Zip::Error
+        nil
+      end
+    end
+  end
+end

--- a/ruby_llm-skills.gemspec
+++ b/ruby_llm-skills.gemspec
@@ -8,33 +8,28 @@ Gem::Specification.new do |spec|
   spec.authors = ["Kieran Klaassen"]
   spec.email = ["kieranklaassen@gmail.com"]
 
-  spec.summary = "TODO: Write a short summary, because RubyGems requires one."
-  spec.description = "TODO: Write a longer description or delete this line."
-  spec.homepage = "TODO: Put your gem's website or public repo URL here."
+  spec.summary = "Agent Skills extension for RubyLLM"
+  spec.description = "Load, validate, and integrate Agent Skills with RubyLLM. " \
+                     "Supports the open Agent Skills specification for progressive " \
+                     "skill discovery and loading from filesystem, zip archives, and databases."
+  spec.homepage = "https://github.com/kieranklaassen/ruby_llm-skills"
+  spec.license = "MIT"
   spec.required_ruby_version = ">= 3.1.0"
 
-  spec.metadata["allowed_push_host"] = "TODO: Set to your gem server 'https://example.com'"
-
   spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = "TODO: Put your gem's public repo URL here."
-  spec.metadata["changelog_uri"] = "TODO: Put your gem's CHANGELOG.md URL here."
+  spec.metadata["source_code_uri"] = "https://github.com/kieranklaassen/ruby_llm-skills"
+  spec.metadata["changelog_uri"] = "https://github.com/kieranklaassen/ruby_llm-skills/blob/main/CHANGELOG.md"
+  spec.metadata["rubygems_mfa_required"] = "true"
 
-  # Specify which files should be added to the gem when it is released.
-  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  gemspec = File.basename(__FILE__)
-  spec.files = IO.popen(%w[git ls-files -z], chdir: __dir__, err: IO::NULL) do |ls|
-    ls.readlines("\x0", chomp: true).reject do |f|
-      (f == gemspec) ||
-        f.start_with?(*%w[bin/ test/ spec/ features/ .git .github appveyor Gemfile])
-    end
-  end
+  spec.files = Dir[
+    "lib/**/*",
+    "LICENSE.txt",
+    "README.md",
+    "CHANGELOG.md"
+  ]
   spec.bindir = "exe"
-  spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
+  spec.executables = []
   spec.require_paths = ["lib"]
 
-  # Uncomment to register a new dependency of your gem
-  # spec.add_dependency "example-gem", "~> 1.0"
-
-  # For more information and examples about making a new gem, check out our
-  # guide at: https://bundler.io/guides/creating_gem.html
+  # No runtime dependencies - rubyzip is optional for ZipLoader
 end

--- a/test/fixtures/skills/invalid-name/SKILL.md
+++ b/test/fixtures/skills/invalid-name/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: Invalid_Name
+description: A skill with an invalid name format
+---
+
+# Invalid Name Skill
+
+This skill has an invalid name (uppercase and underscore).

--- a/test/fixtures/skills/missing-description/SKILL.md
+++ b/test/fixtures/skills/missing-description/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: missing-description
+---
+
+# Missing Description Skill
+
+This skill is missing the required description field.

--- a/test/fixtures/skills/valid-skill/SKILL.md
+++ b/test/fixtures/skills/valid-skill/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: valid-skill
+description: A valid test skill for unit testing
+license: MIT
+compatibility: RubyLLM 1.0+
+metadata:
+  author: test-org
+  version: "1.0"
+allowed-tools: Bash Read
+---
+
+# Valid Skill Instructions
+
+This is a valid skill used for testing the RubyLLM::Skills gem.
+
+## Usage
+
+Use this skill when you need to test skill parsing and loading.
+
+## Steps
+
+1. Load the skill
+2. Verify metadata
+3. Check content

--- a/test/fixtures/skills/with-all-resources/SKILL.md
+++ b/test/fixtures/skills/with-all-resources/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: with-all-resources
+description: A skill with scripts, references, and assets
+license: Apache-2.0
+metadata:
+  category: testing
+  tags: test, complete
+---
+
+# Complete Skill
+
+This skill has all resource types for comprehensive testing.

--- a/test/fixtures/skills/with-all-resources/assets/template.txt
+++ b/test/fixtures/skills/with-all-resources/assets/template.txt
@@ -1,0 +1,1 @@
+Template content for testing asset loading.

--- a/test/fixtures/skills/with-all-resources/references/guide.md
+++ b/test/fixtures/skills/with-all-resources/references/guide.md
@@ -1,0 +1,3 @@
+# Reference Guide
+
+Additional documentation for the skill.

--- a/test/fixtures/skills/with-all-resources/scripts/main.rb
+++ b/test/fixtures/skills/with-all-resources/scripts/main.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+puts "Main script"

--- a/test/fixtures/skills/with-scripts/SKILL.md
+++ b/test/fixtures/skills/with-scripts/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: with-scripts
+description: A skill that includes executable scripts
+---
+
+# Skill With Scripts
+
+This skill includes scripts in the scripts/ directory.

--- a/test/fixtures/skills/with-scripts/scripts/helper.rb
+++ b/test/fixtures/skills/with-scripts/scripts/helper.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# Helper script for testing
+def helper_method
+  "Hello from helper"
+end

--- a/test/fixtures/skills/with-scripts/scripts/setup.sh
+++ b/test/fixtures/skills/with-scripts/scripts/setup.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "Setup script for testing"

--- a/test/ruby_llm/skills/test_database_loader.rb
+++ b/test/ruby_llm/skills/test_database_loader.rb
@@ -1,0 +1,190 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "ruby_llm/skills/database_loader"
+
+class RubyLlm::Skills::TestDatabaseLoader < Minitest::Test
+  def setup
+    @records = [
+      MockRecord.new(id: 1, name: "db-skill-one", description: "First database skill", content: "# Skill One\n\nContent here"),
+      MockRecord.new(id: 2, name: "db-skill-two", description: "Second database skill", content: "# Skill Two")
+    ]
+    @loader = RubyLlm::Skills::DatabaseLoader.new(@records)
+  end
+
+  def test_initialize_with_records
+    loader = RubyLlm::Skills::DatabaseLoader.new(@records)
+    assert_equal @records, loader.records
+  end
+
+  def test_list_returns_skills_array
+    skills = @loader.list
+    assert_instance_of Array, skills
+    assert skills.all? { |s| s.is_a?(RubyLlm::Skills::Skill) }
+  end
+
+  def test_list_creates_skill_for_each_record
+    skills = @loader.list
+    assert_equal 2, skills.length
+  end
+
+  def test_find_returns_skill_by_name
+    skill = @loader.find("db-skill-one")
+    assert_instance_of RubyLlm::Skills::Skill, skill
+    assert_equal "db-skill-one", skill.name
+  end
+
+  def test_find_returns_nil_for_unknown_name
+    skill = @loader.find("nonexistent-skill")
+    assert_nil skill
+  end
+
+  def test_loaded_skill_has_correct_metadata
+    skill = @loader.find("db-skill-one")
+
+    assert_equal "db-skill-one", skill.name
+    assert_equal "First database skill", skill.description
+  end
+
+  def test_loaded_skill_content_is_available
+    skill = @loader.find("db-skill-one")
+    content = skill.content
+
+    assert_includes content, "# Skill One"
+    assert_includes content, "Content here"
+  end
+
+  def test_skill_path_indicates_database_source
+    skill = @loader.find("db-skill-one")
+    assert skill.path.start_with?("database:")
+    assert_includes skill.path, "1"
+  end
+
+  def test_skill_is_virtual
+    skill = @loader.find("db-skill-one")
+    assert skill.virtual?
+  end
+
+  def test_skills_are_cached
+    first_list = @loader.list
+    second_list = @loader.list
+    assert_same first_list, second_list
+  end
+
+  def test_reload_clears_cache
+    initial_skills = @loader.list
+    result = @loader.reload!
+
+    assert_same @loader, result
+    refute_same initial_skills, @loader.list
+  end
+
+  def test_reload_calls_reload_on_records_if_available
+    reloadable = MockReloadableRecords.new(@records)
+    loader = RubyLlm::Skills::DatabaseLoader.new(reloadable)
+
+    loader.reload!
+    assert reloadable.reloaded?
+  end
+
+  def test_optional_license_is_loaded
+    record = MockRecord.new(
+      id: 3,
+      name: "licensed-skill",
+      description: "A skill with license",
+      content: "# Content",
+      license: "MIT"
+    )
+    loader = RubyLlm::Skills::DatabaseLoader.new([record])
+    skill = loader.find("licensed-skill")
+
+    assert_equal "MIT", skill.license
+  end
+
+  def test_optional_compatibility_is_loaded
+    record = MockRecord.new(
+      id: 4,
+      name: "compatible-skill",
+      description: "A skill with compatibility",
+      content: "# Content",
+      compatibility: "RubyLLM 1.0+"
+    )
+    loader = RubyLlm::Skills::DatabaseLoader.new([record])
+    skill = loader.find("compatible-skill")
+
+    assert_equal "RubyLLM 1.0+", skill.compatibility
+  end
+
+  def test_optional_metadata_is_loaded
+    record = MockRecord.new(
+      id: 5,
+      name: "meta-skill",
+      description: "A skill with metadata",
+      content: "# Content",
+      skill_metadata: {"author" => "test", "version" => "1.0"}
+    )
+    loader = RubyLlm::Skills::DatabaseLoader.new([record])
+    skill = loader.find("meta-skill")
+
+    assert_equal({"author" => "test", "version" => "1.0"}, skill.custom_metadata)
+  end
+
+  def test_handles_empty_records
+    loader = RubyLlm::Skills::DatabaseLoader.new([])
+    assert_equal [], loader.list
+  end
+
+  def test_from_database_module_method
+    loader = RubyLlm::Skills.from_database(@records)
+    assert_instance_of RubyLlm::Skills::DatabaseLoader, loader
+  end
+
+  def test_record_without_id_uses_name
+    record = MockRecordWithoutId.new(
+      name: "no-id-skill",
+      description: "Skill without id",
+      content: "# Content"
+    )
+    loader = RubyLlm::Skills::DatabaseLoader.new([record])
+    skill = loader.find("no-id-skill")
+
+    assert_includes skill.path, "no-id-skill"
+  end
+
+  # Mock classes for testing
+  class MockRecord
+    attr_accessor :id, :name, :description, :content, :license, :compatibility, :skill_metadata
+
+    def initialize(attrs = {})
+      attrs.each { |k, v| send("#{k}=", v) }
+    end
+  end
+
+  class MockRecordWithoutId
+    attr_accessor :name, :description, :content
+
+    def initialize(attrs = {})
+      attrs.each { |k, v| send("#{k}=", v) }
+    end
+  end
+
+  class MockReloadableRecords
+    def initialize(records)
+      @records = records
+      @reloaded = false
+    end
+
+    def each(&block)
+      @records.each(&block)
+    end
+
+    def reload
+      @reloaded = true
+      self
+    end
+
+    def reloaded?
+      @reloaded
+    end
+  end
+end

--- a/test/ruby_llm/skills/test_filesystem_loader.rb
+++ b/test/ruby_llm/skills/test_filesystem_loader.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class RubyLlm::Skills::TestFilesystemLoader < Minitest::Test
+  def setup
+    @skills_path = File.join(fixtures_path, "skills")
+    @loader = RubyLlm::Skills::FilesystemLoader.new(@skills_path)
+  end
+
+  def test_initialize_with_path
+    loader = RubyLlm::Skills::FilesystemLoader.new("/path/to/skills")
+    assert_equal "/path/to/skills", loader.path
+  end
+
+  def test_initialize_accepts_pathname
+    require "pathname"
+    loader = RubyLlm::Skills::FilesystemLoader.new(Pathname.new("/path/to/skills"))
+    assert_equal "/path/to/skills", loader.path
+  end
+
+  def test_list_returns_skills_array
+    skills = @loader.list
+    assert_instance_of Array, skills
+    assert skills.all? { |s| s.is_a?(RubyLlm::Skills::Skill) }
+  end
+
+  def test_list_finds_all_skills_in_directory
+    skills = @loader.list
+    skill_names = skills.map(&:name)
+
+    assert_includes skill_names, "valid-skill"
+    assert_includes skill_names, "with-scripts"
+    assert_includes skill_names, "with-all-resources"
+  end
+
+  def test_list_returns_empty_array_for_nonexistent_path
+    loader = RubyLlm::Skills::FilesystemLoader.new("/nonexistent/path")
+    assert_equal [], loader.list
+  end
+
+  def test_list_returns_empty_array_for_empty_directory
+    Dir.mktmpdir do |tmpdir|
+      loader = RubyLlm::Skills::FilesystemLoader.new(tmpdir)
+      assert_equal [], loader.list
+    end
+  end
+
+  def test_find_returns_skill_by_name
+    skill = @loader.find("valid-skill")
+    assert_instance_of RubyLlm::Skills::Skill, skill
+    assert_equal "valid-skill", skill.name
+  end
+
+  def test_find_returns_nil_for_unknown_name
+    skill = @loader.find("nonexistent-skill")
+    assert_nil skill
+  end
+
+  def test_get_returns_skill_by_name
+    skill = @loader.get("valid-skill")
+    assert_instance_of RubyLlm::Skills::Skill, skill
+    assert_equal "valid-skill", skill.name
+  end
+
+  def test_get_raises_not_found_error_for_unknown_name
+    error = assert_raises(RubyLlm::Skills::NotFoundError) do
+      @loader.get("nonexistent-skill")
+    end
+    assert_equal "Skill not found: nonexistent-skill", error.message
+  end
+
+  def test_exists_returns_true_for_existing_skill
+    assert @loader.exists?("valid-skill")
+  end
+
+  def test_exists_returns_false_for_nonexistent_skill
+    refute @loader.exists?("nonexistent-skill")
+  end
+
+  def test_reload_clears_cache
+    # Load skills first
+    initial_skills = @loader.list
+
+    # Reload should clear cache
+    result = @loader.reload!
+
+    assert_same @loader, result
+    refute_same initial_skills, @loader.list
+  end
+
+  def test_skills_are_cached
+    first_list = @loader.list
+    second_list = @loader.list
+
+    assert_same first_list, second_list
+  end
+
+  def test_loaded_skill_has_correct_metadata
+    skill = @loader.find("valid-skill")
+
+    assert_equal "valid-skill", skill.name
+    assert_equal "A valid test skill for unit testing", skill.description
+    assert_equal "MIT", skill.license
+  end
+
+  def test_loaded_skill_can_access_content
+    skill = @loader.find("valid-skill")
+    content = skill.content
+
+    assert_includes content, "# Valid Skill Instructions"
+  end
+
+  def test_loaded_skill_can_list_resources
+    skill = @loader.find("with-all-resources")
+
+    assert_equal 1, skill.scripts.length
+    assert_equal 1, skill.references.length
+    assert_equal 1, skill.assets.length
+  end
+end

--- a/test/ruby_llm/skills/test_module.rb
+++ b/test/ruby_llm/skills/test_module.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class RubyLlm::Skills::TestModule < Minitest::Test
+  def setup
+    @original_default_path = RubyLlm::Skills.default_path
+    @skills_path = File.join(fixtures_path, "skills")
+  end
+
+  def teardown
+    RubyLlm::Skills.default_path = @original_default_path
+  end
+
+  # Configuration tests
+  def test_default_path_defaults_to_app_skills
+    RubyLlm::Skills.default_path = "app/skills"
+    assert_equal "app/skills", RubyLlm::Skills.default_path
+  end
+
+  def test_default_path_is_configurable
+    RubyLlm::Skills.default_path = "custom/skills"
+    assert_equal "custom/skills", RubyLlm::Skills.default_path
+  end
+
+  def test_logger_defaults_to_nil
+    assert_nil RubyLlm::Skills.logger
+  end
+
+  def test_logger_is_configurable
+    logger = Object.new
+    RubyLlm::Skills.logger = logger
+    assert_equal logger, RubyLlm::Skills.logger
+  ensure
+    RubyLlm::Skills.logger = nil
+  end
+
+  # from_directory tests
+  def test_from_directory_returns_filesystem_loader
+    loader = RubyLlm::Skills.from_directory(@skills_path)
+    assert_instance_of RubyLlm::Skills::FilesystemLoader, loader
+  end
+
+  def test_from_directory_uses_default_path_when_no_argument
+    RubyLlm::Skills.default_path = @skills_path
+    loader = RubyLlm::Skills.from_directory
+    assert_equal @skills_path, loader.path
+  end
+
+  def test_from_directory_can_list_skills
+    loader = RubyLlm::Skills.from_directory(@skills_path)
+    skills = loader.list
+    assert skills.any? { |s| s.name == "valid-skill" }
+  end
+
+  # load tests
+  def test_load_returns_skill
+    skill_path = File.join(@skills_path, "valid-skill")
+    skill = RubyLlm::Skills.load(skill_path)
+
+    assert_instance_of RubyLlm::Skills::Skill, skill
+    assert_equal "valid-skill", skill.name
+  end
+
+  def test_load_raises_on_missing_skill_md
+    error = assert_raises(RubyLlm::Skills::LoadError) do
+      RubyLlm::Skills.load("/nonexistent/path")
+    end
+    assert_match(/SKILL.md not found/, error.message)
+  end
+
+  def test_load_parses_skill_content
+    skill_path = File.join(@skills_path, "valid-skill")
+    skill = RubyLlm::Skills.load(skill_path)
+
+    assert_equal "A valid test skill for unit testing", skill.description
+    assert_includes skill.content, "# Valid Skill Instructions"
+  end
+
+  # compose tests
+  def test_compose_returns_composite_loader
+    loader1 = RubyLlm::Skills.from_directory(@skills_path)
+    loader2 = RubyLlm::Skills.from_directory(@skills_path)
+
+    composite = RubyLlm::Skills.compose(loader1, loader2)
+    assert_instance_of RubyLlm::Skills::CompositeLoader, composite
+  end
+
+  def test_compose_combines_skills_from_multiple_loaders
+    loader1 = RubyLlm::Skills.from_directory(@skills_path)
+    loader2 = RubyLlm::Skills.from_directory(@skills_path)
+
+    composite = RubyLlm::Skills.compose(loader1, loader2)
+    skills = composite.list
+
+    # Should have unique skills only (no duplicates)
+    names = skills.map(&:name)
+    assert_equal names.uniq, names
+  end
+
+  def test_compose_earlier_loader_takes_precedence
+    Dir.mktmpdir do |tmpdir|
+      # Create a skill in tmpdir with same name but different description
+      skill_dir = File.join(tmpdir, "valid-skill")
+      FileUtils.mkdir_p(skill_dir)
+      File.write(File.join(skill_dir, "SKILL.md"), <<~SKILL)
+        ---
+        name: valid-skill
+        description: Override description
+        ---
+        Override content
+      SKILL
+
+      loader1 = RubyLlm::Skills.from_directory(tmpdir)
+      loader2 = RubyLlm::Skills.from_directory(@skills_path)
+
+      composite = RubyLlm::Skills.compose(loader1, loader2)
+      skill = composite.find("valid-skill")
+
+      assert_equal "Override description", skill.description
+    end
+  end
+end

--- a/test/ruby_llm/skills/test_parser.rb
+++ b/test/ruby_llm/skills/test_parser.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class RubyLlm::Skills::TestParser < Minitest::Test
+  def test_parse_file_extracts_frontmatter
+    path = File.join(skill_fixture_path("valid-skill"), "SKILL.md")
+    metadata = RubyLlm::Skills::Parser.parse_file(path)
+
+    assert_equal "valid-skill", metadata["name"]
+    assert_equal "A valid test skill for unit testing", metadata["description"]
+    assert_equal "MIT", metadata["license"]
+    assert_equal "RubyLLM 1.0+", metadata["compatibility"]
+  end
+
+  def test_parse_file_extracts_metadata_hash
+    path = File.join(skill_fixture_path("valid-skill"), "SKILL.md")
+    metadata = RubyLlm::Skills::Parser.parse_file(path)
+
+    assert_equal "test-org", metadata["metadata"]["author"]
+    assert_equal "1.0", metadata["metadata"]["version"]
+  end
+
+  def test_parse_file_extracts_allowed_tools
+    path = File.join(skill_fixture_path("valid-skill"), "SKILL.md")
+    metadata = RubyLlm::Skills::Parser.parse_file(path)
+
+    assert_equal "Bash Read", metadata["allowed-tools"]
+  end
+
+  def test_parse_file_raises_on_missing_file
+    error = assert_raises(RubyLlm::Skills::ParseError) do
+      RubyLlm::Skills::Parser.parse_file("/nonexistent/path/SKILL.md")
+    end
+    assert_match(/File not found/, error.message)
+  end
+
+  def test_parse_string_extracts_frontmatter
+    content = <<~SKILL
+      ---
+      name: test-skill
+      description: Test description
+      ---
+      # Content here
+    SKILL
+
+    metadata = RubyLlm::Skills::Parser.parse_string(content)
+    assert_equal "test-skill", metadata["name"]
+    assert_equal "Test description", metadata["description"]
+  end
+
+  def test_parse_string_raises_on_missing_frontmatter
+    content = "# No frontmatter here"
+
+    error = assert_raises(RubyLlm::Skills::ParseError) do
+      RubyLlm::Skills::Parser.parse_string(content)
+    end
+    assert_match(/Missing YAML frontmatter/, error.message)
+  end
+
+  def test_parse_string_raises_on_invalid_yaml
+    content = <<~SKILL
+      ---
+      name: [invalid yaml
+      ---
+      # Content
+    SKILL
+
+    error = assert_raises(RubyLlm::Skills::ParseError) do
+      RubyLlm::Skills::Parser.parse_string(content)
+    end
+    assert_match(/Invalid YAML frontmatter/, error.message)
+  end
+
+  def test_extract_body_returns_content_after_frontmatter
+    content = <<~SKILL
+      ---
+      name: test-skill
+      description: Test
+      ---
+      # Skill Instructions
+
+      This is the body content.
+    SKILL
+
+    body = RubyLlm::Skills::Parser.extract_body(content)
+    assert_equal "# Skill Instructions\n\nThis is the body content.", body
+  end
+
+  def test_extract_body_returns_empty_string_for_invalid_content
+    content = "No frontmatter"
+    body = RubyLlm::Skills::Parser.extract_body(content)
+    assert_equal "", body
+  end
+
+  def test_parse_string_handles_empty_frontmatter
+    content = <<~SKILL
+      ---
+
+      ---
+      # Just content
+    SKILL
+
+    metadata = RubyLlm::Skills::Parser.parse_string(content)
+    assert_equal({}, metadata)
+  end
+end

--- a/test/ruby_llm/skills/test_skill.rb
+++ b/test/ruby_llm/skills/test_skill.rb
@@ -1,0 +1,194 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class RubyLlm::Skills::TestSkill < Minitest::Test
+  def setup
+    @valid_skill_path = skill_fixture_path("valid-skill")
+    @metadata = {
+      "name" => "valid-skill",
+      "description" => "A valid test skill for unit testing",
+      "license" => "MIT",
+      "compatibility" => "RubyLLM 1.0+",
+      "metadata" => {"author" => "test-org", "version" => "1.0"},
+      "allowed-tools" => "Bash Read"
+    }
+  end
+
+  def test_initialize_with_path_and_metadata
+    skill = RubyLlm::Skills::Skill.new(path: @valid_skill_path, metadata: @metadata)
+
+    assert_equal @valid_skill_path, skill.path
+    assert_equal @metadata, skill.metadata
+  end
+
+  def test_name_returns_from_metadata
+    skill = RubyLlm::Skills::Skill.new(path: @valid_skill_path, metadata: @metadata)
+    assert_equal "valid-skill", skill.name
+  end
+
+  def test_description_returns_from_metadata
+    skill = RubyLlm::Skills::Skill.new(path: @valid_skill_path, metadata: @metadata)
+    assert_equal "A valid test skill for unit testing", skill.description
+  end
+
+  def test_license_returns_from_metadata
+    skill = RubyLlm::Skills::Skill.new(path: @valid_skill_path, metadata: @metadata)
+    assert_equal "MIT", skill.license
+  end
+
+  def test_compatibility_returns_from_metadata
+    skill = RubyLlm::Skills::Skill.new(path: @valid_skill_path, metadata: @metadata)
+    assert_equal "RubyLLM 1.0+", skill.compatibility
+  end
+
+  def test_custom_metadata_returns_metadata_hash
+    skill = RubyLlm::Skills::Skill.new(path: @valid_skill_path, metadata: @metadata)
+    assert_equal({"author" => "test-org", "version" => "1.0"}, skill.custom_metadata)
+  end
+
+  def test_custom_metadata_returns_empty_hash_when_missing
+    skill = RubyLlm::Skills::Skill.new(path: @valid_skill_path, metadata: {"name" => "test"})
+    assert_equal({}, skill.custom_metadata)
+  end
+
+  def test_allowed_tools_splits_string
+    skill = RubyLlm::Skills::Skill.new(path: @valid_skill_path, metadata: @metadata)
+    assert_equal %w[Bash Read], skill.allowed_tools
+  end
+
+  def test_allowed_tools_returns_empty_array_when_missing
+    skill = RubyLlm::Skills::Skill.new(path: @valid_skill_path, metadata: {"name" => "test"})
+    assert_equal [], skill.allowed_tools
+  end
+
+  def test_content_loads_lazily_from_file
+    skill = RubyLlm::Skills::Skill.new(path: @valid_skill_path, metadata: @metadata)
+    content = skill.content
+
+    assert_includes content, "# Valid Skill Instructions"
+    assert_includes content, "This is a valid skill used for testing"
+  end
+
+  def test_content_uses_precached_content_when_provided
+    skill = RubyLlm::Skills::Skill.new(
+      path: @valid_skill_path,
+      metadata: @metadata,
+      content: "Pre-loaded content"
+    )
+    assert_equal "Pre-loaded content", skill.content
+  end
+
+  def test_content_uses_metadata_content_key
+    metadata = @metadata.merge("__content__" => "Content from metadata")
+    skill = RubyLlm::Skills::Skill.new(path: @valid_skill_path, metadata: metadata)
+    assert_equal "Content from metadata", skill.content
+  end
+
+  def test_scripts_lists_script_files
+    path = skill_fixture_path("with-scripts")
+    skill = RubyLlm::Skills::Skill.new(
+      path: path,
+      metadata: {"name" => "with-scripts", "description" => "test"}
+    )
+
+    scripts = skill.scripts
+    assert_equal 2, scripts.length
+    assert scripts.any? { |s| s.end_with?("helper.rb") }
+    assert scripts.any? { |s| s.end_with?("setup.sh") }
+  end
+
+  def test_scripts_returns_empty_array_when_no_scripts_dir
+    skill = RubyLlm::Skills::Skill.new(path: @valid_skill_path, metadata: @metadata)
+    assert_equal [], skill.scripts
+  end
+
+  def test_references_lists_reference_files
+    path = skill_fixture_path("with-all-resources")
+    skill = RubyLlm::Skills::Skill.new(
+      path: path,
+      metadata: {"name" => "with-all-resources", "description" => "test"}
+    )
+
+    references = skill.references
+    assert_equal 1, references.length
+    assert references.first.end_with?("guide.md")
+  end
+
+  def test_assets_lists_asset_files
+    path = skill_fixture_path("with-all-resources")
+    skill = RubyLlm::Skills::Skill.new(
+      path: path,
+      metadata: {"name" => "with-all-resources", "description" => "test"}
+    )
+
+    assets = skill.assets
+    assert_equal 1, assets.length
+    assert assets.first.end_with?("template.txt")
+  end
+
+  def test_filesystem_returns_true_for_filesystem_path
+    skill = RubyLlm::Skills::Skill.new(path: @valid_skill_path, metadata: @metadata)
+    assert skill.filesystem?
+  end
+
+  def test_virtual_returns_false_for_filesystem_path
+    skill = RubyLlm::Skills::Skill.new(path: @valid_skill_path, metadata: @metadata)
+    refute skill.virtual?
+  end
+
+  def test_virtual_returns_true_for_database_path
+    skill = RubyLlm::Skills::Skill.new(path: "database:123", metadata: @metadata)
+    assert skill.virtual?
+  end
+
+  def test_filesystem_returns_false_for_database_path
+    skill = RubyLlm::Skills::Skill.new(path: "database:123", metadata: @metadata)
+    refute skill.filesystem?
+  end
+
+  def test_skill_md_path_returns_path_for_filesystem
+    skill = RubyLlm::Skills::Skill.new(path: @valid_skill_path, metadata: @metadata)
+    expected = File.join(@valid_skill_path, "SKILL.md")
+    assert_equal expected, skill.skill_md_path
+  end
+
+  def test_skill_md_path_returns_nil_for_virtual
+    skill = RubyLlm::Skills::Skill.new(path: "database:123", metadata: @metadata)
+    assert_nil skill.skill_md_path
+  end
+
+  def test_content_returns_empty_for_virtual_skill
+    skill = RubyLlm::Skills::Skill.new(path: "database:123", metadata: {"name" => "test"})
+    assert_equal "", skill.content
+  end
+
+  def test_resources_return_empty_for_virtual_skill
+    skill = RubyLlm::Skills::Skill.new(path: "database:123", metadata: {"name" => "test"})
+    assert_equal [], skill.scripts
+    assert_equal [], skill.references
+    assert_equal [], skill.assets
+  end
+
+  def test_reload_clears_cached_values
+    skill = RubyLlm::Skills::Skill.new(path: @valid_skill_path, metadata: @metadata)
+
+    # Load content to cache it
+    skill.content
+    skill.scripts
+
+    # Reload should clear cache
+    result = skill.reload!
+
+    assert_same skill, result
+  end
+
+  def test_inspect_returns_readable_string
+    skill = RubyLlm::Skills::Skill.new(path: @valid_skill_path, metadata: @metadata)
+    inspect_str = skill.inspect
+
+    assert_includes inspect_str, "RubyLlm::Skills::Skill"
+    assert_includes inspect_str, "valid-skill"
+    assert_includes inspect_str, @valid_skill_path
+  end
+end

--- a/test/ruby_llm/skills/test_skill_tool.rb
+++ b/test/ruby_llm/skills/test_skill_tool.rb
@@ -1,0 +1,182 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class RubyLlm::Skills::TestSkillTool < Minitest::Test
+  def setup
+    @skills_path = File.join(fixtures_path, "skills")
+    @loader = RubyLlm::Skills::FilesystemLoader.new(@skills_path)
+    @tool = RubyLlm::Skills::SkillTool.new(@loader)
+  end
+
+  def test_initialize_with_loader
+    tool = RubyLlm::Skills::SkillTool.new(@loader)
+    assert_equal @loader, tool.loader
+  end
+
+  def test_name_returns_skill
+    assert_equal "skill", @tool.name
+  end
+
+  def test_description_includes_available_skills_xml
+    description = @tool.description
+
+    assert_includes description, "<available_skills>"
+    assert_includes description, "</available_skills>"
+    assert_includes description, "<skill>"
+    assert_includes description, "<name>valid-skill</name>"
+    assert_includes description, "<description>A valid test skill for unit testing</description>"
+  end
+
+  def test_description_includes_all_skills
+    description = @tool.description
+
+    assert_includes description, "valid-skill"
+    assert_includes description, "with-scripts"
+    assert_includes description, "with-all-resources"
+  end
+
+  def test_description_escapes_xml_special_chars
+    # Create a mock loader with special characters
+    mock_skill = RubyLlm::Skills::Skill.new(
+      path: "database:test",
+      metadata: {
+        "name" => "test-skill",
+        "description" => "Test <with> special & \"chars'"
+      }
+    )
+    mock_loader = MockLoader.new([mock_skill])
+    tool = RubyLlm::Skills::SkillTool.new(mock_loader)
+
+    description = tool.description
+    assert_includes description, "&lt;with&gt;"
+    assert_includes description, "&amp;"
+    assert_includes description, "&quot;"
+    assert_includes description, "&apos;"
+  end
+
+  def test_parameters_returns_json_schema
+    params = @tool.parameters
+
+    assert_equal "object", params[:type]
+    assert params[:properties].key?(:skill_name)
+    assert_equal "string", params[:properties][:skill_name][:type]
+    assert_includes params[:required], "skill_name"
+  end
+
+  def test_call_returns_skill_content
+    result = @tool.call(skill_name: "valid-skill")
+
+    assert_includes result, "# Skill: valid-skill"
+    assert_includes result, "# Valid Skill Instructions"
+    assert_includes result, "This is a valid skill used for testing"
+  end
+
+  def test_call_returns_error_for_unknown_skill
+    result = @tool.call(skill_name: "nonexistent-skill")
+
+    assert_includes result, "Skill 'nonexistent-skill' not found"
+    assert_includes result, "Available skills:"
+  end
+
+  def test_execute_is_alias_for_call
+    result = @tool.execute(skill_name: "valid-skill")
+
+    assert_includes result, "# Skill: valid-skill"
+  end
+
+  def test_call_includes_scripts_section_when_present
+    result = @tool.call(skill_name: "with-scripts")
+
+    assert_includes result, "## Available Scripts"
+    assert_includes result, "helper.rb"
+    assert_includes result, "setup.sh"
+  end
+
+  def test_call_includes_references_section_when_present
+    result = @tool.call(skill_name: "with-all-resources")
+
+    assert_includes result, "## Available References"
+    assert_includes result, "guide.md"
+  end
+
+  def test_call_includes_assets_section_when_present
+    result = @tool.call(skill_name: "with-all-resources")
+
+    assert_includes result, "## Available Assets"
+    assert_includes result, "template.txt"
+  end
+
+  def test_to_tool_definition_returns_complete_definition
+    definition = @tool.to_tool_definition
+
+    assert_equal "skill", definition[:name]
+    assert definition[:description].is_a?(String)
+    assert definition[:parameters].is_a?(Hash)
+  end
+
+  def test_description_handles_empty_loader
+    empty_loader = RubyLlm::Skills::FilesystemLoader.new("/nonexistent/path")
+    tool = RubyLlm::Skills::SkillTool.new(empty_loader)
+
+    description = tool.description
+    assert_includes description, "<available_skills>"
+    assert_includes description, "No skills available"
+  end
+
+  def test_works_with_database_loader
+    require "ruby_llm/skills/database_loader"
+
+    records = [
+      MockDatabaseRecord.new(
+        id: 1,
+        name: "db-skill",
+        description: "A database skill",
+        content: "# Database Skill Content"
+      )
+    ]
+    loader = RubyLlm::Skills::DatabaseLoader.new(records)
+    tool = RubyLlm::Skills::SkillTool.new(loader)
+
+    description = tool.description
+    assert_includes description, "<name>db-skill</name>"
+
+    result = tool.call(skill_name: "db-skill")
+    assert_includes result, "# Database Skill Content"
+  end
+
+  def test_works_with_composite_loader
+    loader1 = RubyLlm::Skills::FilesystemLoader.new(@skills_path)
+    composite = RubyLlm::Skills::CompositeLoader.new([loader1])
+    tool = RubyLlm::Skills::SkillTool.new(composite)
+
+    description = tool.description
+    assert_includes description, "valid-skill"
+
+    result = tool.call(skill_name: "valid-skill")
+    assert_includes result, "# Valid Skill Instructions"
+  end
+
+  # Mock classes for testing
+  class MockLoader
+    def initialize(skills)
+      @skills = skills
+    end
+
+    def list
+      @skills
+    end
+
+    def find(name)
+      @skills.find { |s| s.name == name }
+    end
+  end
+
+  class MockDatabaseRecord
+    attr_accessor :id, :name, :description, :content
+
+    def initialize(attrs = {})
+      attrs.each { |k, v| send("#{k}=", v) }
+    end
+  end
+end

--- a/test/ruby_llm/skills/test_validator.rb
+++ b/test/ruby_llm/skills/test_validator.rb
@@ -1,0 +1,201 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class RubyLlm::Skills::TestValidator < Minitest::Test
+  def test_valid_skill_returns_no_errors
+    skill = build_skill(name: "valid-skill", description: "A valid description")
+    errors = RubyLlm::Skills::Validator.validate(skill)
+    assert_empty errors
+  end
+
+  def test_valid_returns_true_for_valid_skill
+    skill = build_skill(name: "valid-skill", description: "A valid description")
+    assert RubyLlm::Skills::Validator.valid?(skill)
+  end
+
+  def test_valid_returns_false_for_invalid_skill
+    skill = build_skill(name: nil, description: "A description")
+    refute RubyLlm::Skills::Validator.valid?(skill)
+  end
+
+  # Name validation tests
+  def test_missing_name_returns_error
+    skill = build_skill(name: nil, description: "A description")
+    errors = RubyLlm::Skills::Validator.validate(skill)
+    assert_includes errors, "name is required"
+  end
+
+  def test_empty_name_returns_error
+    skill = build_skill(name: "", description: "A description")
+    errors = RubyLlm::Skills::Validator.validate(skill)
+    assert_includes errors, "name is required"
+  end
+
+  def test_name_too_long_returns_error
+    skill = build_skill(name: "a" * 65, description: "A description")
+    errors = RubyLlm::Skills::Validator.validate(skill)
+    assert errors.any? { |e| e.include?("name exceeds maximum length") }
+  end
+
+  def test_name_with_uppercase_returns_error
+    skill = build_skill(name: "Invalid-Name", description: "A description")
+    errors = RubyLlm::Skills::Validator.validate(skill)
+    assert errors.any? { |e| e.include?("must be lowercase") }
+  end
+
+  def test_name_with_underscore_returns_error
+    skill = build_skill(name: "invalid_name", description: "A description")
+    errors = RubyLlm::Skills::Validator.validate(skill)
+    assert errors.any? { |e| e.include?("must be lowercase") }
+  end
+
+  def test_name_starting_with_hyphen_returns_error
+    skill = build_skill(name: "-invalid", description: "A description")
+    errors = RubyLlm::Skills::Validator.validate(skill)
+    assert errors.any? { |e| e.include?("must be lowercase") }
+  end
+
+  def test_name_ending_with_hyphen_returns_error
+    skill = build_skill(name: "invalid-", description: "A description")
+    errors = RubyLlm::Skills::Validator.validate(skill)
+    assert errors.any? { |e| e.include?("must be lowercase") }
+  end
+
+  def test_name_with_consecutive_hyphens_returns_error
+    skill = build_skill(name: "invalid--name", description: "A description")
+    errors = RubyLlm::Skills::Validator.validate(skill)
+    assert errors.any? { |e| e.include?("must be lowercase") }
+  end
+
+  def test_valid_names_accepted
+    valid_names = %w[skill my-skill skill123 my-123-skill a1-b2-c3]
+    valid_names.each do |name|
+      skill = build_skill(name: name, description: "A description", path: "/path/to/#{name}")
+      errors = RubyLlm::Skills::Validator.validate(skill)
+      assert_empty errors, "Expected '#{name}' to be valid but got: #{errors.inspect}"
+    end
+  end
+
+  # Description validation tests
+  def test_missing_description_returns_error
+    skill = build_skill(name: "valid-skill", description: nil)
+    errors = RubyLlm::Skills::Validator.validate(skill)
+    assert_includes errors, "description is required"
+  end
+
+  def test_empty_description_returns_error
+    skill = build_skill(name: "valid-skill", description: "")
+    errors = RubyLlm::Skills::Validator.validate(skill)
+    assert_includes errors, "description is required"
+  end
+
+  def test_description_too_long_returns_error
+    skill = build_skill(name: "valid-skill", description: "a" * 1025)
+    errors = RubyLlm::Skills::Validator.validate(skill)
+    assert errors.any? { |e| e.include?("description exceeds maximum length") }
+  end
+
+  # License validation tests
+  def test_license_too_long_returns_error
+    skill = build_skill(
+      name: "valid-skill",
+      description: "A description",
+      license: "a" * 129
+    )
+    errors = RubyLlm::Skills::Validator.validate(skill)
+    assert errors.any? { |e| e.include?("license exceeds maximum length") }
+  end
+
+  def test_valid_license_accepted
+    skill = build_skill(
+      name: "valid-skill",
+      description: "A description",
+      license: "MIT"
+    )
+    errors = RubyLlm::Skills::Validator.validate(skill)
+    assert_empty errors
+  end
+
+  # Compatibility validation tests
+  def test_compatibility_too_long_returns_error
+    skill = build_skill(
+      name: "valid-skill",
+      description: "A description",
+      compatibility: "a" * 501
+    )
+    errors = RubyLlm::Skills::Validator.validate(skill)
+    assert errors.any? { |e| e.include?("compatibility exceeds maximum length") }
+  end
+
+  def test_valid_compatibility_accepted
+    skill = build_skill(
+      name: "valid-skill",
+      description: "A description",
+      compatibility: "RubyLLM 1.0+"
+    )
+    errors = RubyLlm::Skills::Validator.validate(skill)
+    assert_empty errors
+  end
+
+  # Path-name match validation tests
+  def test_path_name_mismatch_returns_error
+    skill = build_skill(
+      name: "skill-name",
+      description: "A description",
+      path: "/path/to/different-name"
+    )
+    errors = RubyLlm::Skills::Validator.validate(skill)
+    assert errors.any? { |e| e.include?("does not match directory name") }
+  end
+
+  def test_path_name_match_passes
+    skill = build_skill(
+      name: "my-skill",
+      description: "A description",
+      path: "/path/to/my-skill"
+    )
+    errors = RubyLlm::Skills::Validator.validate(skill)
+    assert_empty errors
+  end
+
+  def test_virtual_skill_skips_path_validation
+    skill = build_skill(
+      name: "my-skill",
+      description: "A description",
+      path: "database:123"
+    )
+    errors = RubyLlm::Skills::Validator.validate(skill)
+    assert_empty errors
+  end
+
+  # Integration with Skill#valid? and Skill#errors
+  def test_skill_valid_method
+    path = skill_fixture_path("valid-skill")
+    metadata = RubyLlm::Skills::Parser.parse_file(File.join(path, "SKILL.md"))
+    skill = RubyLlm::Skills::Skill.new(path: path, metadata: metadata)
+
+    assert skill.valid?
+    assert_empty skill.errors
+  end
+
+  def test_skill_errors_method_returns_validation_errors
+    path = skill_fixture_path("missing-description")
+    metadata = RubyLlm::Skills::Parser.parse_file(File.join(path, "SKILL.md"))
+    skill = RubyLlm::Skills::Skill.new(path: path, metadata: metadata)
+
+    refute skill.valid?
+    assert_includes skill.errors, "description is required"
+  end
+
+  private
+
+  def build_skill(name:, description:, path: nil, license: nil, compatibility: nil)
+    path ||= "/path/to/#{name || "skill"}"
+    metadata = {"name" => name, "description" => description}
+    metadata["license"] = license if license
+    metadata["compatibility"] = compatibility if compatibility
+
+    RubyLlm::Skills::Skill.new(path: path, metadata: metadata)
+  end
+end

--- a/test/ruby_llm/skills/test_zip_loader.rb
+++ b/test/ruby_llm/skills/test_zip_loader.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "ruby_llm/skills/zip_loader"
+require "tmpdir"
+
+class RubyLlm::Skills::TestZipLoader < Minitest::Test
+  def setup
+    @zip_path = create_test_zip
+    @loader = RubyLlm::Skills::ZipLoader.new(@zip_path)
+  end
+
+  def teardown
+    File.delete(@zip_path) if @zip_path && File.exist?(@zip_path)
+  end
+
+  def test_initialize_with_path
+    assert_equal @zip_path, @loader.path
+  end
+
+  def test_initialize_raises_on_missing_file
+    error = assert_raises(RubyLlm::Skills::LoadError) do
+      RubyLlm::Skills::ZipLoader.new("/nonexistent/file.zip")
+    end
+    assert_match(/Zip file not found/, error.message)
+  end
+
+  def test_list_returns_skills_array
+    skills = @loader.list
+    assert_instance_of Array, skills
+    assert skills.all? { |s| s.is_a?(RubyLlm::Skills::Skill) }
+  end
+
+  def test_list_finds_skills_in_archive
+    skills = @loader.list
+    skill_names = skills.map(&:name)
+
+    assert_includes skill_names, "zip-skill-one"
+    assert_includes skill_names, "zip-skill-two"
+  end
+
+  def test_find_returns_skill_by_name
+    skill = @loader.find("zip-skill-one")
+    assert_instance_of RubyLlm::Skills::Skill, skill
+    assert_equal "zip-skill-one", skill.name
+  end
+
+  def test_find_returns_nil_for_unknown_name
+    skill = @loader.find("nonexistent-skill")
+    assert_nil skill
+  end
+
+  def test_loaded_skill_has_correct_metadata
+    skill = @loader.find("zip-skill-one")
+
+    assert_equal "zip-skill-one", skill.name
+    assert_equal "First zip skill", skill.description
+  end
+
+  def test_loaded_skill_content_is_available
+    skill = @loader.find("zip-skill-one")
+    content = skill.content
+
+    assert_includes content, "# Zip Skill One"
+    assert_includes content, "Instructions for the first skill"
+  end
+
+  def test_skill_path_indicates_zip_source
+    skill = @loader.find("zip-skill-one")
+    assert skill.path.start_with?("zip:")
+    assert_includes skill.path, @zip_path
+  end
+
+  def test_skill_is_virtual
+    skill = @loader.find("zip-skill-one")
+    # Zip skills have paths like "zip:/path/to/file.zip:skill-name"
+    # They're not database: prefixed, so not virtual in that sense
+    refute skill.virtual?
+  end
+
+  def test_read_file_returns_file_content
+    content = @loader.read_file("zip-skill-one", "scripts/helper.rb")
+    assert_includes content, "helper code"
+  end
+
+  def test_read_file_returns_nil_for_missing_file
+    content = @loader.read_file("zip-skill-one", "nonexistent.txt")
+    assert_nil content
+  end
+
+  def test_skills_are_cached
+    first_list = @loader.list
+    second_list = @loader.list
+    assert_same first_list, second_list
+  end
+
+  def test_reload_clears_cache
+    initial_skills = @loader.list
+    result = @loader.reload!
+
+    assert_same @loader, result
+    refute_same initial_skills, @loader.list
+  end
+
+  def test_list_returns_empty_for_empty_zip
+    empty_zip = create_empty_zip
+    loader = RubyLlm::Skills::ZipLoader.new(empty_zip)
+
+    assert_equal [], loader.list
+  ensure
+    File.delete(empty_zip) if empty_zip && File.exist?(empty_zip)
+  end
+
+  def test_from_zip_module_method
+    loader = RubyLlm::Skills.from_zip(@zip_path)
+    assert_instance_of RubyLlm::Skills::ZipLoader, loader
+  end
+
+  private
+
+  def create_test_zip
+    zip_path = File.join(Dir.tmpdir, "test_skills_#{Time.now.to_i}.zip")
+
+    Zip::File.open(zip_path, Zip::File::CREATE) do |zip|
+      # Skill one with scripts
+      zip.get_output_stream("zip-skill-one/SKILL.md") do |f|
+        f.puts <<~SKILL
+          ---
+          name: zip-skill-one
+          description: First zip skill
+          ---
+          # Zip Skill One
+
+          Instructions for the first skill.
+        SKILL
+      end
+
+      zip.get_output_stream("zip-skill-one/scripts/helper.rb") do |f|
+        f.puts "# helper code"
+      end
+
+      # Skill two
+      zip.get_output_stream("zip-skill-two/SKILL.md") do |f|
+        f.puts <<~SKILL
+          ---
+          name: zip-skill-two
+          description: Second zip skill
+          ---
+          # Zip Skill Two
+        SKILL
+      end
+    end
+
+    zip_path
+  end
+
+  def create_empty_zip
+    zip_path = File.join(Dir.tmpdir, "empty_skills_#{Time.now.to_i}.zip")
+    Zip::File.open(zip_path, Zip::File::CREATE) { |_| }
+    zip_path
+  end
+end

--- a/test/ruby_llm/test_skills.rb
+++ b/test/ruby_llm/test_skills.rb
@@ -7,7 +7,7 @@ class RubyLlm::TestSkills < Minitest::Test
     refute_nil ::RubyLlm::Skills::VERSION
   end
 
-  def test_it_does_something_useful
-    assert false
+  def test_module_exists
+    assert defined?(RubyLlm::Skills)
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,3 +4,17 @@ $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "ruby_llm/skills"
 
 require "minitest/autorun"
+
+module FixturesHelper
+  def fixtures_path
+    File.expand_path("fixtures", __dir__)
+  end
+
+  def skill_fixture_path(name)
+    File.join(fixtures_path, "skills", name)
+  end
+end
+
+class Minitest::Test
+  include FixturesHelper
+end


### PR DESCRIPTION
## Summary

Implements the complete RubyLLM::Skills gem following the [Agent Skills specification](https://agentskills.io/specification).

### Core Components
- `Parser` - YAML frontmatter parsing with safe_load
- `Skill` - Lazy loading for content and resources
- `Validator` - Agent Skills spec validation rules

### Loading System
- `FilesystemLoader` - Directory-based skill loading
- `ZipLoader` - Archive-based skill loading (optional rubyzip)
- `DatabaseLoader` - Duck-typed record loading (text or binary)
- `CompositeLoader` - Multi-source skill combination

### LLM Integration
- `SkillTool` - Progressive disclosure via dynamic `<available_skills>` XML
- `ChatExtensions` - `with_skills()` and `with_skill_loader()` methods

### Rails Integration
- Railtie auto-configures `app/skills` path
- Generator: `rails g skill my-skill`
- Rake tasks: `skills:list`, `skills:validate`, `skills:show`

## Testing

- 142 tests, 291 assertions
- All loaders tested (filesystem, zip, database, composite)
- SkillTool integration tested

## Test Plan

- [x] All tests pass locally
- [x] Manual testing of all loaders
- [x] CI configured with Ruby 3.1, 3.2, 3.3 matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)