### PR TITLE
feat: add skills DSL integration for RubyLLM::Agent

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     ruby_llm-skills (0.2.0)
-      ruby_llm (>= 1.12)
+      ruby_llm (~> 1.12)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     ruby_llm-skills (0.2.0)
-      ruby_llm (>= 1.10)
+      ruby_llm (>= 1.12)
 
 GEM
   remote: https://rubygems.org/
@@ -19,7 +19,7 @@ GEM
     dotenv (3.2.0)
     erb (6.0.0)
     event_stream_parser (1.0.0)
-    faraday (2.14.0)
+    faraday (2.14.1)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
@@ -35,7 +35,7 @@ GEM
       pp (>= 0.6.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    json (2.18.0)
+    json (2.18.1)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
@@ -86,13 +86,13 @@ GEM
       rubocop (>= 1.75.0, < 2.0)
       rubocop-ast (>= 1.38.0, < 2.0)
     ruby-progressbar (1.13.0)
-    ruby_llm (1.10.0)
+    ruby_llm (1.12.0)
       base64
       event_stream_parser (~> 1)
-      faraday (>= 1.10.0)
+      faraday (>= 2.0)
       faraday-multipart (>= 1)
       faraday-net_http (>= 1)
-      faraday-retry (>= 1)
+      faraday-retry (>= 2.0)
       marcel (~> 1.0)
       ruby_llm-schema (~> 0.2.1)
       zeitwerk (~> 2)

--- a/README.md
+++ b/README.md
@@ -31,6 +31,23 @@ chat.with_skills("app/skills", "app/commands") # multiple paths
 chat.with_skills("app/skills", user.skills)   # with database records
 ```
 
+### With RubyLLM::Agent (v1.12+)
+
+```ruby
+class SupportAgent < RubyLLM::Agent
+  model "gpt-5-nano"
+  instructions "You are a support assistant."
+  skills "app/skills", only: [:faq, :troubleshooting]
+end
+
+chat = SupportAgent.chat
+chat.ask("How do I reset my password?")
+
+agent = SupportAgent.new
+agent.with_skills("extra/skills")
+agent.ask("What can you help with?")
+```
+
 ## Creating Skills
 
 ```

--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ agent.with_skills("extra/skills")
 agent.ask("What can you help with?")
 ```
 
+`agent.with_skills(...)` replaces the current skill tool configuration.
+To combine sources, pass all sources in a single `skills`/`with_skills` call.
+
 ## Creating Skills
 
 ```

--- a/docs/plans/2026-02-17-feat-agent-skills-dsl-integration-plan.md
+++ b/docs/plans/2026-02-17-feat-agent-skills-dsl-integration-plan.md
@@ -1,0 +1,420 @@
+---
+title: "feat: Add skills DSL to RubyLLM::Agent"
+type: feat
+status: active
+date: 2026-02-17
+---
+
+# Add skills DSL to RubyLLM::Agent
+
+## Overview
+
+RubyLLM 1.12 introduces `RubyLLM::Agent` — a class-configured agent DSL with macros like `model`, `instructions`, `tools`, and `temperature`. Currently, `ruby_llm-skills` only integrates with `RubyLLM::Chat` via `ChatExtensions`. This plan adds a `skills` DSL macro to `RubyLLM::Agent` so skills work seamlessly in agent subclasses, matching the existing `tools` pattern.
+
+## Problem Statement
+
+Users defining agents with the new DSL have no way to declaratively add skills:
+
+```ruby
+# This works today:
+chat = RubyLLM.chat.with_skills("app/skills")
+
+# This doesn't:
+class SupportAgent < RubyLLM::Agent
+  skills "app/skills", only: [:faq, :troubleshooting]  # ← not available
+end
+```
+
+## Proposed Solution
+
+Add an `AgentExtensions` module that extends `RubyLLM::Agent` with:
+
+1. **Class-level `skills` macro** — stores skill sources and options, supports blocks/lambdas for dynamic resolution (consistent with `tools` macro pattern)
+2. **`apply_skills` hook** — called during `apply_configuration` via `prepend`, applies skills to the internal chat
+3. **Instance-level `with_skills`** — delegates to the internal chat for programmatic usage (via `Agent.new`)
+
+### DSL Examples
+
+```ruby
+# Static skills from a path
+class SimpleAgent < RubyLLM::Agent
+  model 'gpt-4.1'
+  skills "app/skills"
+end
+
+# Multiple sources with filtering
+class SupportAgent < RubyLLM::Agent
+  model 'claude-sonnet-4-5-20250929'
+  instructions "You are a support assistant."
+  tools SearchDocs, LookupAccount
+  skills "app/skills", only: [:faq, :troubleshooting]
+  temperature 0.2
+end
+
+# Dynamic skills via block (has access to runtime context)
+class WorkAssistant < RubyLLM::Agent
+  inputs :workspace
+  skills { [workspace.skill_collection] }
+end
+
+# Instance-level usage (via Agent.new, not .chat)
+agent = SupportAgent.new
+agent.with_skills("extra/skills")
+agent.ask("Help me")
+
+# .chat returns a RubyLLM::Chat which already has ChatExtensions
+chat = SupportAgent.chat
+chat.with_skills("extra/skills").ask("Help me")
+```
+
+> **Note:** `skills` with no arguments is a getter (returns the current config), matching the `tools` macro pattern. To load from the default path, use `skills RubyLLM::Skills.default_path` explicitly.
+
+## Technical Approach
+
+### Architecture
+
+```
+lib/ruby_llm/skills/
+├── agent_extensions.rb    # NEW: AgentExtensions module
+├── chat_extensions.rb     # EXISTING: unchanged
+└── ...
+
+lib/ruby_llm/skills.rb    # MODIFIED: require + include AgentExtensions
+```
+
+### Implementation
+
+#### Phase 1: `AgentExtensions` Module
+
+Create `lib/ruby_llm/skills/agent_extensions.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+module RubyLLM
+  module Skills
+    # Extensions for RubyLLM::Agent to enable declarative skill configuration.
+    #
+    # @example Static skills
+    #   class MyAgent < RubyLLM::Agent
+    #     skills "app/skills", only: [:greeting]
+    #   end
+    #
+    # @example Dynamic skills
+    #   class MyAgent < RubyLLM::Agent
+    #     inputs :workspace
+    #     skills { [workspace.skill_collection] }
+    #   end
+    #
+    module AgentExtensions
+      module ClassMethods
+        def self.extended(base)
+          base.instance_variable_set(:@skill_sources, nil)
+          base.instance_variable_set(:@skill_only, nil)
+        end
+
+        def inherited(subclass)
+          super
+          subclass.instance_variable_set(:@skill_sources, @skill_sources&.dup)
+          subclass.instance_variable_set(:@skill_only, @skill_only&.dup)
+        end
+
+        # Declare skill sources for this agent.
+        #
+        # Called with no arguments, returns the current config (getter).
+        # Called with sources/block, sets the skill config (setter).
+        #
+        # @param sources [Array<String>] skill source paths
+        # @param only [Array<Symbol, String>, nil] filter to specific skills
+        # @return [Hash] when called as getter
+        def skills(*sources, only: nil, &block)
+          if sources.empty? && only.nil? && !block_given?
+            return {sources: @skill_sources, only: @skill_only}
+          end
+
+          @skill_sources = block_given? ? block : sources
+          @skill_only = only
+        end
+      end
+
+      module InstanceMethods
+        # Add skills to this agent instance at runtime.
+        #
+        # @param sources [Array] skill sources
+        # @param only [Array<Symbol, String>, nil] filter
+        # @return [self] for chaining
+        def with_skills(*sources, only: nil)
+          chat.with_skills(*sources, only: only)
+          self
+        end
+      end
+
+      module ConfigurationPatch
+        private
+
+        def apply_configuration(chat_object, **kwargs)
+          super
+          input_values = kwargs[:input_values] || {}
+          apply_skills(llm_chat_for(chat_object),
+            runtime_context(chat: chat_object, inputs: input_values))
+        end
+
+        def apply_skills(llm_chat, runtime)
+          config = skills
+          sources = config[:sources]
+          return if sources.nil?
+
+          resolved = sources.is_a?(Proc) ? Array(runtime.instance_exec(&sources)) : sources
+          only = config[:only]
+
+          llm_chat.with_skills(*resolved, only: only)
+        end
+      end
+
+      def self.included(base)
+        base.extend(ClassMethods)
+        base.include(InstanceMethods)
+        base.singleton_class.prepend(ConfigurationPatch)
+      end
+    end
+  end
+end
+```
+
+Key design decisions:
+
+- **`prepend` on singleton class** for `ConfigurationPatch` — hooks into `apply_configuration` without replacing it. Calls `super` first so all standard configuration (model, tools, instructions, etc.) happens, then applies skills.
+- **`**kwargs` passthrough** — uses `**kwargs` instead of explicit keyword arguments for resilience against upstream signature changes in `apply_configuration`.
+- **`inherited` hook** — copies `@skill_sources` and `@skill_only` to subclasses, matching how Agent copies `@tools`, `@temperature`, etc. Calls `super` to chain with Agent's own `inherited`.
+- **Block support** — evaluated at runtime via the same `runtime_context` pattern Agent uses for `tools` and `params`.
+- **No-arg `skills` is a getter** — matches the `tools` macro convention. Users must explicitly provide a path.
+- **Instance `with_skills`** — delegates to `chat` (the `@chat` attr_reader from Agent), returns `self` for chaining. Only reachable via `Agent.new`, since `.chat` class method returns a bare `RubyLLM::Chat` (which already has `ChatExtensions`).
+
+#### Phase 2: Wire It Up
+
+Modify `lib/ruby_llm/skills.rb`:
+
+```ruby
+# After line 12 (require chat_extensions):
+require_relative "skills/agent_extensions"
+
+# After line 18 (Chat.include):
+RubyLLM::Agent.include(RubyLLM::Skills::AgentExtensions)
+```
+
+No `if defined?` guard needed since we're bumping the dependency to >= 1.12.
+
+#### Phase 3: Bump Dependency
+
+In `ruby_llm-skills.gemspec`, change:
+
+```ruby
+spec.add_dependency "ruby_llm", ">= 1.12"
+```
+
+#### Phase 4: Tests
+
+Create `test/ruby_llm/skills/test_agent_extensions.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestAgentExtensions < Minitest::Test
+  include FixturesHelper
+
+  # --- Class-level DSL ---
+
+  def test_skills_macro_stores_sources
+    agent_class = Class.new(RubyLLM::Agent) { skills "app/skills" }
+    config = agent_class.skills
+    assert_equal ["app/skills"], config[:sources]
+    assert_nil config[:only]
+  end
+
+  def test_skills_macro_with_only_filter
+    agent_class = Class.new(RubyLLM::Agent) {
+      skills "app/skills", only: [:greeting]
+    }
+    assert_equal [:greeting], agent_class.skills[:only]
+  end
+
+  def test_skills_macro_with_multiple_sources
+    agent_class = Class.new(RubyLLM::Agent) {
+      skills "app/skills", "app/commands"
+    }
+    assert_equal ["app/skills", "app/commands"], agent_class.skills[:sources]
+  end
+
+  def test_skills_macro_with_block
+    agent_class = Class.new(RubyLLM::Agent) {
+      skills { ["dynamic/path"] }
+    }
+    assert agent_class.skills[:sources].is_a?(Proc)
+  end
+
+  def test_skills_no_args_is_getter
+    agent_class = Class.new(RubyLLM::Agent)
+    config = agent_class.skills
+    assert_nil config[:sources]
+    assert_nil config[:only]
+  end
+
+  # --- Inheritance ---
+
+  def test_skills_inherited_by_subclass
+    parent = Class.new(RubyLLM::Agent) {
+      skills "app/skills", only: [:greeting]
+    }
+    child = Class.new(parent)
+    assert_equal ["app/skills"], child.skills[:sources]
+    assert_equal [:greeting], child.skills[:only]
+  end
+
+  def test_child_can_override_parent_skills
+    parent = Class.new(RubyLLM::Agent) { skills "parent/skills" }
+    child = Class.new(parent) { skills "child/skills" }
+    assert_equal ["child/skills"], child.skills[:sources]
+    assert_equal ["parent/skills"], parent.skills[:sources]
+  end
+
+  # --- Combined with tools ---
+
+  def test_skills_and_tools_coexist
+    tool_class = Class.new(RubyLLM::Tool) do
+      description "Test tool"
+      def execute = "ok"
+    end
+
+    agent_class = Class.new(RubyLLM::Agent) {
+      tools tool_class
+      skills "app/skills"
+    }
+
+    assert_equal [tool_class], agent_class.tools
+    assert_equal ["app/skills"], agent_class.skills[:sources]
+  end
+
+  # --- apply_configuration integration ---
+
+  def test_agent_chat_registers_skill_tool
+    agent_class = Class.new(RubyLLM::Agent) {
+      skills fixtures_path
+    }
+    chat = agent_class.chat
+    assert chat.tools.key?(:skill), "Expected :skill tool to be registered"
+  end
+
+  def test_agent_new_registers_skill_tool
+    agent_class = Class.new(RubyLLM::Agent) {
+      skills fixtures_path
+    }
+    agent = agent_class.new
+    assert agent.chat.tools.key?(:skill)
+  end
+
+  def test_agent_without_skills_has_no_skill_tool
+    agent_class = Class.new(RubyLLM::Agent)
+    chat = agent_class.chat
+    refute chat.tools.key?(:skill)
+  end
+
+  # --- Instance-level with_skills ---
+
+  def test_instance_with_skills_adds_to_chat
+    agent_class = Class.new(RubyLLM::Agent)
+    agent = agent_class.new
+    result = agent.with_skills(fixtures_path)
+    assert_equal agent, result  # returns self
+    assert agent.chat.tools.key?(:skill)
+  end
+end
+```
+
+Integration test in `test/ruby_llm/skills/test_agent_integration.rb` (VCR-recorded):
+
+```ruby
+# frozen_string_literal: true
+
+require "integration_helper"
+
+class TestAgentIntegration < Minitest::Test
+  include FixturesHelper
+
+  def test_agent_with_skills_can_discover_and_use_skills
+    agent_class = Class.new(RubyLLM::Agent) do
+      model "gpt-4.1-mini"
+      skills fixtures_path
+    end
+
+    VCR.use_cassette("agent_with_skills") do
+      chat = agent_class.chat
+      response = chat.ask("What skills do you have available?")
+      assert response.content.length > 0
+    end
+  end
+end
+```
+
+#### Phase 5: Update README / Documentation
+
+Add Agent usage examples to README alongside existing Chat examples. Brief section:
+
+```markdown
+### With RubyLLM::Agent (v1.12+)
+
+```ruby
+class SupportAgent < RubyLLM::Agent
+  model 'gpt-4.1'
+  skills "app/skills", only: [:faq, :troubleshooting]
+end
+
+chat = SupportAgent.chat
+chat.ask("How do I reset my password?")
+```
+```
+
+## Acceptance Criteria
+
+- [x] `skills` class macro works on `RubyLLM::Agent` subclasses (static sources, `only:` filter, block form)
+- [x] `skills` no-arg is a getter (returns `{sources:, only:}`)
+- [x] Skills are inherited by Agent subclasses; child can override parent
+- [x] `apply_configuration` applies skills to the internal chat after standard config
+- [x] Both `.chat` and `.new` entry points apply skills correctly
+- [x] Skills and tools coexist without conflict
+- [x] Instance-level `with_skills` works on Agent instances (via `.new`)
+- [x] Block-based skills have access to runtime context (`chat`, declared `inputs`)
+- [x] `ruby_llm` dependency bumped to `>= 1.12`
+- [x] Unit tests for all DSL variations pass
+- [x] Integration test with VCR proves end-to-end functionality
+- [x] StandardRB linting passes
+
+## Known Considerations
+
+### SkillTool name collision with `with_tool`
+
+`Chat#with_tool` stores tools in a hash keyed by `tool_instance.name.to_sym`. `SkillTool` always uses name `:skill`. This means:
+- Calling `with_skills` twice replaces the previous SkillTool (not duplicates) — this is correct behavior.
+- The class-level `skills` DSL and instance-level `with_skills` cannot stack independently — the second call replaces the first. This is acceptable; users who need multiple sources should list them all in a single `skills` call.
+
+### Private method dependency
+
+`ConfigurationPatch` calls `llm_chat_for` and `runtime_context` — both private methods on `RubyLLM::Agent`'s singleton class. Using `**kwargs` passthrough mitigates signature changes, but these method names could change in future versions. Pinning to `~> 1.12` would reduce this risk.
+
+### `.chat` vs `.new` return types
+
+`Agent.chat` returns a `RubyLLM::Chat` (not an Agent instance). `Agent.new` returns an Agent with a `chat` accessor. Both paths go through `apply_configuration`, so skills are applied in both cases. The instance-level `with_skills` on AgentExtensions is only reachable via `.new`.
+
+## Dependencies & Risks
+
+- **RubyLLM 1.12 must be released and installable** — the Agent class must be available. If 1.12 is not yet on RubyGems, we may need to point at a git ref temporarily.
+- **`prepend` on singleton class** — cleanest way to hook into `apply_configuration`. Calls `super` so upstream changes are preserved.
+- **No Rails-specific changes needed** — the Railtie already extends `ChatExtensions` onto `acts_as_chat` models. Agent integration works at the Ruby level, independent of Rails.
+
+## References
+
+- [RubyLLM 1.12 Agents blog post](https://paolino.me/rubyllm-1-12-agents/)
+- RubyLLM Agent source: `lib/ruby_llm/agent.rb` (upstream)
+- Current Chat integration: `lib/ruby_llm/skills/chat_extensions.rb`
+- Current skills entry point: `lib/ruby_llm/skills.rb:18`

--- a/lib/ruby_llm/skills/agent_extensions.rb
+++ b/lib/ruby_llm/skills/agent_extensions.rb
@@ -16,6 +16,8 @@ module RubyLLM
     #   end
     #
     module AgentExtensions
+      REQUIRED_AGENT_SINGLETON_METHODS = %i[apply_configuration runtime_context llm_chat_for].freeze
+
       module ClassMethods
         def self.extended(base)
           base.instance_variable_set(:@skill_sources, nil)
@@ -38,11 +40,38 @@ module RubyLLM
         # @return [Hash] current configuration when called as a getter
         def skills(*sources, only: nil, &block)
           if sources.empty? && only.nil? && !block_given?
-            return {sources: @skill_sources, only: @skill_only}
+            return {
+              sources: @skill_sources.is_a?(Proc) ? @skill_sources : @skill_sources&.dup,
+              only: @skill_only&.dup
+            }
           end
 
-          @skill_sources = block_given? ? block : sources
-          @skill_only = only
+          @skill_sources = block_given? ? block : normalize_skill_sources(sources)
+          @skill_only = only&.dup
+        end
+
+        private
+
+        def normalize_skill_sources(raw_sources)
+          flatten_skill_sources(raw_sources).compact
+        end
+
+        def flatten_skill_sources(source)
+          return [] if source.nil?
+          return [source] if source.is_a?(String)
+          return [source] if loader_source?(source)
+          return [source] if database_collection_source?(source)
+          return source.flat_map { |item| flatten_skill_sources(item) } if source.is_a?(Array)
+
+          [source]
+        end
+
+        def loader_source?(source)
+          source.respond_to?(:list) && source.respond_to?(:find)
+        end
+
+        def database_collection_source?(source)
+          source.respond_to?(:to_a) && source.first&.respond_to?(:name) && source.first.respond_to?(:content)
         end
       end
 
@@ -79,11 +108,37 @@ module RubyLLM
             sources
           end
 
-          llm_chat.with_skills(*Array(resolved_sources), only: config[:only])
+          normalized_sources = normalize_skill_sources(resolved_sources)
+          return if normalized_sources.empty?
+
+          validate_skill_sources!(normalized_sources)
+          llm_chat.with_skills(*normalized_sources, only: config[:only])
+        end
+
+        def validate_skill_sources!(sources)
+          invalid_sources = sources.reject { |source| valid_skill_source?(source) }
+          return if invalid_sources.empty?
+
+          invalid_types = invalid_sources.map { |source| source.class.name || source.class.to_s }.uniq.join(", ")
+          raise ArgumentError,
+            "Invalid skill source(s): #{invalid_types}. Expected String path, Loader, or record collection."
+        end
+
+        def valid_skill_source?(source)
+          source.is_a?(String) || loader_source?(source) || database_collection_source?(source)
         end
       end
 
       def self.included(base)
+        missing_methods = REQUIRED_AGENT_SINGLETON_METHODS.reject do |method_name|
+          base.singleton_class.private_method_defined?(method_name) || base.singleton_class.method_defined?(method_name)
+        end
+
+        if missing_methods.any?
+          raise LoadError,
+            "RubyLLM::Agent is missing required methods for ruby_llm-skills integration: #{missing_methods.join(", ")}"
+        end
+
         base.extend(ClassMethods)
         base.include(InstanceMethods)
         base.singleton_class.prepend(ConfigurationPatch)

--- a/lib/ruby_llm/skills/agent_extensions.rb
+++ b/lib/ruby_llm/skills/agent_extensions.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+module RubyLLM
+  module Skills
+    # Extensions for RubyLLM::Agent to enable declarative skill configuration.
+    #
+    # @example Static skills
+    #   class SupportAgent < RubyLLM::Agent
+    #     skills "app/skills", only: [:faq]
+    #   end
+    #
+    # @example Dynamic skills
+    #   class WorkspaceAgent < RubyLLM::Agent
+    #     inputs :workspace
+    #     skills { [workspace.skill_collection] }
+    #   end
+    #
+    module AgentExtensions
+      module ClassMethods
+        def self.extended(base)
+          base.instance_variable_set(:@skill_sources, nil)
+          base.instance_variable_set(:@skill_only, nil)
+        end
+
+        def inherited(subclass)
+          super
+          subclass.instance_variable_set(:@skill_sources, @skill_sources.is_a?(Proc) ? @skill_sources : @skill_sources&.dup)
+          subclass.instance_variable_set(:@skill_only, @skill_only&.dup)
+        end
+
+        # Declare skill sources for this agent class.
+        #
+        # Called with no arguments, returns the current configuration.
+        # Called with sources or a block, sets the configuration.
+        #
+        # @param sources [Array] skill sources
+        # @param only [Array<Symbol, String>, nil] include only these skills
+        # @return [Hash] current configuration when called as a getter
+        def skills(*sources, only: nil, &block)
+          if sources.empty? && only.nil? && !block_given?
+            return {sources: @skill_sources, only: @skill_only}
+          end
+
+          @skill_sources = block_given? ? block : sources
+          @skill_only = only
+        end
+      end
+
+      module InstanceMethods
+        # Add skills to this agent instance at runtime.
+        #
+        # @param sources [Array] skill sources
+        # @param only [Array<Symbol, String>, nil] include only these skills
+        # @return [self] for chaining
+        def with_skills(*sources, only: nil)
+          chat.with_skills(*sources, only: only)
+          self
+        end
+      end
+
+      module ConfigurationPatch
+        private
+
+        def apply_configuration(chat_object, **kwargs)
+          super
+          input_values = kwargs[:input_values] || {}
+          runtime = runtime_context(chat: chat_object, inputs: input_values)
+          apply_skills(llm_chat_for(chat_object), runtime)
+        end
+
+        def apply_skills(llm_chat, runtime)
+          config = skills
+          sources = config[:sources]
+          return if sources.nil?
+
+          resolved_sources = if sources.is_a?(Proc)
+            runtime.instance_exec(&sources)
+          else
+            sources
+          end
+
+          llm_chat.with_skills(*Array(resolved_sources), only: config[:only])
+        end
+      end
+
+      def self.included(base)
+        base.extend(ClassMethods)
+        base.include(InstanceMethods)
+        base.singleton_class.prepend(ConfigurationPatch)
+      end
+    end
+  end
+end

--- a/lib/ruby_llm/skills/chat_extensions.rb
+++ b/lib/ruby_llm/skills/chat_extensions.rb
@@ -41,11 +41,22 @@ module RubyLLM
         case source
         when String
           RubyLLM::Skills.from_directory(source)
-        when ->(s) { s.respond_to?(:to_a) && s.first&.respond_to?(:name) && s.first.respond_to?(:content) }
+        when ->(s) { database_collection_source?(s) }
           RubyLLM::Skills.from_database(source)
-        else
+        when ->(s) { loader_source?(s) }
           source
+        else
+          raise ArgumentError,
+            "Invalid skill source: #{source.class}. Expected String path, Loader, or record collection."
         end
+      end
+
+      def loader_source?(source)
+        source.respond_to?(:list) && source.respond_to?(:find)
+      end
+
+      def database_collection_source?(source)
+        source.respond_to?(:to_a) && source.first&.respond_to?(:name) && source.first.respond_to?(:content)
       end
     end
 

--- a/ruby_llm-skills.gemspec
+++ b/ruby_llm-skills.gemspec
@@ -31,6 +31,6 @@ Gem::Specification.new do |spec|
   spec.executables = []
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "ruby_llm", ">= 1.10"
+  spec.add_dependency "ruby_llm", ">= 1.12"
   # rubyzip is optional for ZipLoader
 end

--- a/ruby_llm-skills.gemspec
+++ b/ruby_llm-skills.gemspec
@@ -31,6 +31,6 @@ Gem::Specification.new do |spec|
   spec.executables = []
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "ruby_llm", ">= 1.12"
+  spec.add_dependency "ruby_llm", "~> 1.12"
   # rubyzip is optional for ZipLoader
 end

--- a/test/ruby_llm/skills/test_agent_extensions.rb
+++ b/test/ruby_llm/skills/test_agent_extensions.rb
@@ -1,0 +1,178 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class RubyLLM::Skills::TestAgentExtensions < Minitest::Test
+  def setup
+    RubyLLM.configure do |config|
+      config.openai_api_key = ENV.fetch("OPENAI_API_KEY", "test-key")
+    end
+    @skills_path = File.join(fixtures_path, "skills")
+  end
+
+  # --- Class-level DSL ---
+
+  def test_skills_macro_stores_sources
+    agent_class = Class.new(RubyLLM::Agent) { skills "app/skills" }
+    config = agent_class.skills
+
+    assert_equal ["app/skills"], config[:sources]
+    assert_nil config[:only]
+  end
+
+  def test_skills_macro_with_only_filter
+    agent_class = Class.new(RubyLLM::Agent) do
+      skills "app/skills", only: [:valid_skill]
+    end
+
+    assert_equal [:valid_skill], agent_class.skills[:only]
+  end
+
+  def test_skills_macro_with_multiple_sources
+    agent_class = Class.new(RubyLLM::Agent) do
+      skills "app/skills", "app/commands"
+    end
+
+    assert_equal ["app/skills", "app/commands"], agent_class.skills[:sources]
+  end
+
+  def test_skills_macro_with_block
+    agent_class = Class.new(RubyLLM::Agent) do
+      skills { ["dynamic/path"] }
+    end
+
+    assert agent_class.skills[:sources].is_a?(Proc)
+  end
+
+  def test_skills_no_args_is_getter
+    agent_class = Class.new(RubyLLM::Agent)
+    config = agent_class.skills
+
+    assert_nil config[:sources]
+    assert_nil config[:only]
+  end
+
+  # --- Inheritance ---
+
+  def test_skills_inherited_by_subclass
+    parent = Class.new(RubyLLM::Agent) do
+      skills "app/skills", only: [:valid_skill]
+    end
+    child = Class.new(parent)
+
+    assert_equal ["app/skills"], child.skills[:sources]
+    assert_equal [:valid_skill], child.skills[:only]
+  end
+
+  def test_child_can_override_parent_skills
+    parent = Class.new(RubyLLM::Agent) { skills "parent/skills" }
+    child = Class.new(parent) { skills "child/skills" }
+
+    assert_equal ["child/skills"], child.skills[:sources]
+    assert_equal ["parent/skills"], parent.skills[:sources]
+  end
+
+  # --- Combined with tools ---
+
+  def test_skills_and_tools_coexist
+    tool_class = Class.new(RubyLLM::Tool) do
+      description "Test tool"
+
+      def execute
+        "ok"
+      end
+    end
+
+    agent_class = Class.new(RubyLLM::Agent) do
+      tools tool_class
+      skills "app/skills"
+    end
+
+    assert_equal [tool_class], agent_class.tools
+    assert_equal ["app/skills"], agent_class.skills[:sources]
+  end
+
+  # --- apply_configuration integration ---
+
+  def test_agent_chat_registers_skill_tool
+    path = @skills_path
+    agent_class = Class.new(RubyLLM::Agent) do
+      model "gpt-5-nano"
+      skills path
+    end
+
+    chat = agent_class.chat
+    assert chat.tools.key?(:skill), "Expected :skill tool to be registered"
+  end
+
+  def test_agent_new_registers_skill_tool
+    path = @skills_path
+    agent_class = Class.new(RubyLLM::Agent) do
+      model "gpt-5-nano"
+      skills path
+    end
+
+    agent = agent_class.new
+    assert agent.chat.tools.key?(:skill)
+  end
+
+  def test_agent_without_skills_has_no_skill_tool
+    agent_class = Class.new(RubyLLM::Agent) { model "gpt-5-nano" }
+    chat = agent_class.chat
+
+    refute chat.tools.key?(:skill)
+  end
+
+  def test_agent_applies_only_filter
+    path = @skills_path
+    agent_class = Class.new(RubyLLM::Agent) do
+      model "gpt-5-nano"
+      skills path, only: ["valid-skill"]
+    end
+
+    chat = agent_class.chat
+    description = chat.tools.fetch(:skill).description
+
+    assert_includes description, "<name>valid-skill</name>"
+    refute_includes description, "<name>with-scripts</name>"
+  end
+
+  def test_block_based_skills_can_access_runtime_inputs
+    path = @skills_path
+    agent_class = Class.new(RubyLLM::Agent) do
+      model "gpt-5-nano"
+      inputs :skill_source
+      skills { [skill_source] }
+    end
+
+    chat = agent_class.chat(skill_source: path)
+    assert chat.tools.key?(:skill)
+  end
+
+  def test_block_based_skills_can_access_runtime_chat
+    path = @skills_path
+    agent_class = Class.new(RubyLLM::Agent) do
+      model "gpt-5-nano"
+      inputs :skill_source
+      skills do
+        raise "runtime chat missing tools accessor" unless chat.respond_to?(:tools)
+        [skill_source]
+      end
+    end
+
+    chat = agent_class.chat(skill_source: path)
+    assert chat.tools.key?(:skill)
+  end
+
+  # --- Instance-level with_skills ---
+
+  def test_instance_with_skills_adds_to_chat
+    agent_class = Class.new(RubyLLM::Agent) { model "gpt-5-nano" }
+    agent = agent_class.new
+
+    result = agent.with_skills(@skills_path)
+
+    assert_equal agent, result
+    assert agent.chat.tools.key?(:skill)
+  end
+end

--- a/test/ruby_llm/skills/test_agent_integration.rb
+++ b/test/ruby_llm/skills/test_agent_integration.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "integration_helper"
+
+class RubyLLM::Skills::TestAgentIntegration < Minitest::Test
+  def test_agent_with_skills_can_discover_and_use_skills
+    skills_path = File.join(fixtures_path, "skills")
+    agent_class = Class.new(RubyLLM::Agent) do
+      model "gpt-5-nano"
+      skills skills_path
+    end
+
+    VCR.use_cassette("with_skills_basic") do
+      chat = agent_class.chat
+      response = chat.ask("I need help with the valid-skill, can you load it?")
+      assert_includes response.content.downcase, "valid-skill"
+    end
+  end
+end

--- a/test/ruby_llm/skills/test_delegate_compat.rb
+++ b/test/ruby_llm/skills/test_delegate_compat.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class RubyLLM::Skills::TestDelegateCompat < Minitest::Test
+  def test_delegate_supports_prefix_keyword
+    klass = Class.new do
+      def value
+        "hello"
+      end
+
+      delegate :upcase, to: :value, prefix: true
+    end
+
+    assert_equal "HELLO", klass.new.value_upcase
+  end
+
+  def test_delegate_supports_allow_nil_keyword
+    klass = Class.new do
+      def value
+        nil
+      end
+
+      delegate :upcase, to: :value, allow_nil: true
+    end
+
+    assert_nil klass.new.upcase
+  end
+end

--- a/todos/001-complete-p1-agent-skills-dsl-integration.md
+++ b/todos/001-complete-p1-agent-skills-dsl-integration.md
@@ -1,5 +1,5 @@
 ---
-status: ready
+status: complete
 priority: p1
 issue_id: "001"
 tags: [ruby_llm, agent, skills, dsl]
@@ -68,7 +68,7 @@ Implement AgentExtensions, wire it in the entrypoint, bump dependency to RubyLLM
 - [x] Update README with Agent usage
 - [x] Run tests and standardrb successfully
 - [x] Update plan checkboxes as tasks complete
-- [ ] Create commit and PR
+- [x] Create commit and PR
 
 ## Work Log
 
@@ -107,3 +107,15 @@ Implement AgentExtensions, wire it in the entrypoint, bump dependency to RubyLLM
 **Learnings:**
 - `ruby_llm` 1.12.0 requires `delegate` availability for `Agent` in non-Rails environments
 - Reusing existing VCR cassette (`with_skills_basic`) provides stable Agent integration coverage without new network recordings
+
+### 2026-02-17 - Ship
+
+**By:** Codex
+
+**Actions:**
+- Created commit `e2bb63f` with feature implementation
+- Pushed branch `feat/agent-skills-dsl-integration`
+- Opened PR: https://github.com/kieranklaassen/ruby_llm-skills/pull/2
+
+**Learnings:**
+- Existing untracked local artifacts can trigger GH CLI \"uncommitted change\" warnings without blocking PR creation

--- a/todos/001-ready-p1-agent-skills-dsl-integration.md
+++ b/todos/001-ready-p1-agent-skills-dsl-integration.md
@@ -1,0 +1,109 @@
+---
+status: ready
+priority: p1
+issue_id: "001"
+tags: [ruby_llm, agent, skills, dsl]
+dependencies: []
+---
+
+# Add skills DSL support to RubyLLM::Agent
+
+Implement `RubyLLM::Skills::AgentExtensions` so `RubyLLM::Agent` classes can declare and apply skills via `skills` macro, matching existing chat/tool patterns.
+
+## Problem Statement
+
+`ruby_llm-skills` currently extends `RubyLLM::Chat` only. `RubyLLM::Agent` subclasses cannot declare skills via DSL, so users lose declarative configuration when moving to Agent-based workflows.
+
+## Findings
+
+- `RubyLLM::Agent` in ruby_llm 1.12.0 applies class DSL through singleton `apply_configuration`.
+- The extension point is safe via singleton `prepend` and `super` chaining.
+- `lib/ruby_llm/skills.rb` currently includes only `ChatExtensions`.
+- Gem dependency is currently `ruby_llm >= 1.10`; Agent support requires 1.12+.
+
+## Proposed Solutions
+
+### Option 1: Add AgentExtensions with singleton prepend (selected)
+
+**Approach:** Create `AgentExtensions` with class `skills` macro, instance `with_skills`, and singleton patch to call `apply_skills` after existing agent configuration.
+
+**Pros:**
+- Minimal and consistent with `Agent` DSL behavior
+- Supports inheritance and runtime proc evaluation
+- Keeps ChatExtensions unchanged
+
+**Cons:**
+- Depends on private Agent singleton helper methods
+
+**Effort:** 2-4 hours
+
+**Risk:** Low
+
+## Recommended Action
+
+Implement AgentExtensions, wire it in the entrypoint, bump dependency to RubyLLM >= 1.12, add unit/integration tests and README examples, then run tests + lint and open PR.
+
+## Technical Details
+
+**Affected files:**
+- `lib/ruby_llm/skills/agent_extensions.rb`
+- `lib/ruby_llm/skills.rb`
+- `ruby_llm-skills.gemspec`
+- `Gemfile.lock`
+- `test/ruby_llm/skills/test_agent_extensions.rb`
+- `test/ruby_llm/skills/test_agent_integration.rb`
+- `README.md`
+- `docs/plans/2026-02-17-feat-agent-skills-dsl-integration-plan.md`
+
+## Acceptance Criteria
+
+- [x] Add class-level `skills` macro with sources/only/block support
+- [x] Add instance-level `with_skills` delegating to chat
+- [x] Apply skills during Agent `apply_configuration`
+- [x] Ensure inheritance/override behavior for skill config
+- [x] Wire extension in `lib/ruby_llm/skills.rb`
+- [x] Bump dependency to `ruby_llm >= 1.12`
+- [x] Add unit tests for DSL and configuration behavior
+- [x] Add integration coverage for Agent + skills flow
+- [x] Update README with Agent usage
+- [x] Run tests and standardrb successfully
+- [x] Update plan checkboxes as tasks complete
+- [ ] Create commit and PR
+
+## Work Log
+
+### 2026-02-17 - Initialization
+
+**By:** Codex
+
+**Actions:**
+- Read work plan and repository conventions
+- Validated `ruby_llm` 1.12.0 Agent implementation from gem payload
+- Created feature branch `feat/agent-skills-dsl-integration`
+- Created execution todo file
+
+**Learnings:**
+- `Agent.apply_configuration` signature uses `input_values:` and `persist_instructions:` keywords
+- Existing integration test strategy relies on VCR cassettes in `test/fixtures/vcr_cassettes`
+
+### 2026-02-17 - Implementation and validation
+
+**By:** Codex
+
+**Actions:**
+- Added `lib/ruby_llm/skills/agent_extensions.rb` with `skills` DSL, runtime `with_skills`, and singleton `apply_configuration` patch
+- Wired extension in `lib/ruby_llm/skills.rb`
+- Bumped `ruby_llm` dependency to `>= 1.12` and updated lockfile to 1.12.0
+- Added a minimal `delegate` fallback shim for plain Ruby environments before requiring `ruby_llm`
+- Added `test/ruby_llm/skills/test_agent_extensions.rb` and `test/ruby_llm/skills/test_agent_integration.rb`
+- Updated README with `RubyLLM::Agent` usage examples
+- Ran validation:
+  - `bundle exec ruby -Itest test/ruby_llm/skills/test_agent_extensions.rb`
+  - `bundle exec ruby -Itest test/ruby_llm/skills/test_agent_integration.rb`
+  - `bundle exec rake test`
+  - `bundle exec rake standard`
+- Checked off acceptance criteria in plan doc
+
+**Learnings:**
+- `ruby_llm` 1.12.0 requires `delegate` availability for `Agent` in non-Rails environments
+- Reusing existing VCR cassette (`with_skills_basic`) provides stable Agent integration coverage without new network recordings

--- a/todos/002-complete-p1-dynamic-skills-default-path-escalation.md
+++ b/todos/002-complete-p1-dynamic-skills-default-path-escalation.md
@@ -1,0 +1,108 @@
+---
+status: complete
+priority: p1
+issue_id: "002"
+tags: [code-review, security, agent, ruby_llm, correctness]
+dependencies: []
+---
+
+# Dynamic skills nil/empty falls back to default path
+
+A dynamic `skills { ... }` block that resolves to `nil` or `[]` still registers skills from `RubyLLM::Skills.default_path`, which can expose capabilities that should be disabled.
+
+## Problem Statement
+
+The Agent DSL should allow request-time logic to disable skills. Current behavior silently loads default skills instead, breaking least-privilege expectations.
+
+## Findings
+
+- `AgentExtensions#apply_skills` always calls `with_skills(*Array(resolved_sources), ...)`.
+- `ChatExtensions#with_skills` treats no sources as default path.
+- Reproduction confirms `skills { nil }` still exposes `valid-skill` when default path points to fixtures.
+- Evidence references:
+  - `lib/ruby_llm/skills/agent_extensions.rb:76`
+  - `lib/ruby_llm/skills/agent_extensions.rb:82`
+  - `lib/ruby_llm/skills/chat_extensions.rb:28`
+
+## Proposed Solutions
+
+### Option 1: Guard empty resolved sources (recommended)
+
+**Approach:** In `apply_skills`, return early when resolved sources are `nil`/empty.
+
+**Pros:**
+- Preserves intent of dynamic “no skills” configuration
+- Minimal code change
+- No global behavior changes
+
+**Cons:**
+- Slight behavior change for callers currently relying on implicit fallback
+
+**Effort:** Small
+
+**Risk:** Low
+
+---
+
+### Option 2: Add explicit fallback flag
+
+**Approach:** Add `use_default: true/false` in DSL to control fallback behavior.
+
+**Pros:**
+- Explicit API semantics
+- Backward-compatibility path possible
+
+**Cons:**
+- API surface expansion
+- More docs/tests required
+
+**Effort:** Medium
+
+**Risk:** Medium
+
+## Recommended Action
+
+
+## Technical Details
+
+**Affected files:**
+- `lib/ruby_llm/skills/agent_extensions.rb`
+- `lib/ruby_llm/skills/chat_extensions.rb`
+- `test/ruby_llm/skills/test_agent_extensions.rb`
+
+## Resources
+
+- PR: https://github.com/kieranklaassen/ruby_llm-skills/pull/2
+- Reproduction command output from review session (`skills { nil }` -> `valid-skill` visible)
+
+## Acceptance Criteria
+
+- [x] `skills { nil }` does not register any `:skill` tool
+- [x] `skills { [] }` does not register any `:skill` tool
+- [x] Existing explicit `skills "path"` behavior remains unchanged
+- [x] Regression tests added for nil/empty dynamic sources
+
+## Work Log
+
+### 2026-02-17 - Code Review Finding
+
+**By:** Codex
+
+**Actions:**
+- Confirmed behavior via direct runtime reproduction
+- Correlated with parallel reviewer findings
+
+**Learnings:**
+- Empty dynamic sources currently map to implicit default-path behavior
+
+### 2026-02-17 - Resolution
+
+**By:** Codex
+
+**Actions:**
+- Updated `AgentExtensions#apply_skills` to normalize and short-circuit empty sources
+- Added regression tests for `skills { nil }` and `skills { [] }` behavior
+- Verified explicit source behavior remains unchanged
+
+**Learnings:**
+- Empty dynamic sources should map to "no skill tool" rather than implicit default fallback

--- a/todos/003-complete-p2-skills-source-shape-runtime-crash.md
+++ b/todos/003-complete-p2-skills-source-shape-runtime-crash.md
@@ -1,0 +1,107 @@
+---
+status: complete
+priority: p2
+issue_id: "003"
+tags: [code-review, reliability, agent, ruby_llm, quality]
+dependencies: []
+---
+
+# Nested/invalid skills source shapes can crash at runtime
+
+`skills` stores sources without normalizing shape. Passing arrays/collections in common patterns can produce invalid loaders and raise `NoMethodError`.
+
+## Problem Statement
+
+Agent DSL should fail predictably or normalize input. Current behavior allows nested arrays/non-loader objects to flow into `SkillTool`, then crashes when tool description calls `loader.list`.
+
+## Findings
+
+- `skills paths` (where `paths` is an array) stores nested arrays.
+- Tool building later raises `undefined method 'list' for Array`.
+- Dynamic blocks returning non-loader collections can also fail similarly.
+- Evidence references:
+  - `lib/ruby_llm/skills/agent_extensions.rb:44`
+  - `lib/ruby_llm/skills/agent_extensions.rb:82`
+  - `lib/ruby_llm/skills/chat_extensions.rb:40`
+  - `lib/ruby_llm/skills/skill_tool.rb:108`
+
+## Proposed Solutions
+
+### Option 1: Normalize sources before delegation (recommended)
+
+**Approach:** Flatten one level and reject unsupported source types early with a clear error.
+
+**Pros:**
+- Prevents late runtime crashes
+- Improves DSL ergonomics (`skills paths` works)
+
+**Cons:**
+- Needs careful handling for database collections
+
+**Effort:** Small
+
+**Risk:** Low
+
+---
+
+### Option 2: Strict validation with descriptive ArgumentError
+
+**Approach:** Keep current shape rules but raise early unless each source is String/loader/database-compatible.
+
+**Pros:**
+- Very explicit contract
+- Safer than implicit coercion
+
+**Cons:**
+- Less ergonomic for callers
+
+**Effort:** Small
+
+**Risk:** Low
+
+## Recommended Action
+
+
+## Technical Details
+
+**Affected files:**
+- `lib/ruby_llm/skills/agent_extensions.rb`
+- `lib/ruby_llm/skills/chat_extensions.rb`
+- `test/ruby_llm/skills/test_agent_extensions.rb`
+
+## Resources
+
+- PR: https://github.com/kieranklaassen/ruby_llm-skills/pull/2
+- Reproduction command output from review session (`skills paths` crash)
+
+## Acceptance Criteria
+
+- [x] `skills paths` (array variable) works or fails early with clear error
+- [x] Dynamic block returning unsupported object types fails with descriptive error
+- [x] Regression tests cover nested arrays and invalid dynamic outputs
+
+## Work Log
+
+### 2026-02-17 - Code Review Finding
+
+**By:** Codex
+
+**Actions:**
+- Reproduced `NoMethodError` with nested source arrays
+- Verified failure originates in `SkillTool#build_skills_xml`
+
+**Learnings:**
+- Late failure path makes debugging harder than upfront validation
+
+### 2026-02-17 - Resolution
+
+**By:** Codex
+
+**Actions:**
+- Added source normalization in `skills` DSL to flatten nested source arrays safely
+- Added early source validation with descriptive `ArgumentError`
+- Hardened `ChatExtensions#to_loader` to reject invalid source objects immediately
+- Added regression tests for array-variable sources and invalid dynamic source outputs
+
+**Learnings:**
+- Early validation produces actionable errors and avoids deep runtime crashes in tool rendering

--- a/todos/004-complete-p2-global-delegate-monkey-patch-risk.md
+++ b/todos/004-complete-p2-global-delegate-monkey-patch-risk.md
@@ -1,0 +1,100 @@
+---
+status: complete
+priority: p2
+issue_id: "004"
+tags: [code-review, architecture, compatibility, ruby]
+dependencies: []
+---
+
+# Global Module#delegate patch introduces compatibility risk
+
+The gem entrypoint globally defines `Module#delegate` if missing. The shim supports only `to:` and alters process-wide behavior.
+
+## Problem Statement
+
+Patching `Module` in library load path is high-impact. Incomplete method signature can break other code expecting richer delegate semantics.
+
+## Findings
+
+- Shim lives in `lib/ruby_llm/skills.rb` and affects entire process.
+- Direct repro: `delegate :to_s, to: :bar, prefix: true` raises `ArgumentError: unknown keyword: :prefix`.
+- Evidence references:
+  - `lib/ruby_llm/skills.rb:5`
+  - `lib/ruby_llm/skills.rb:7`
+
+## Proposed Solutions
+
+### Option 1: Load canonical delegation extension (recommended)
+
+**Approach:** Prefer requiring ActiveSupport delegation extension when available, or isolate shim behind explicit compatibility module.
+
+**Pros:**
+- Avoids custom global behavior drift
+- Better compatibility with ecosystem expectations
+
+**Cons:**
+- Adds optional dependency concerns
+
+**Effort:** Medium
+
+**Risk:** Medium
+
+---
+
+### Option 2: Expand shim compatibility
+
+**Approach:** Support full keyword signature (`prefix`, etc.) and document limitations clearly.
+
+**Pros:**
+- Keeps no-extra-dependency approach
+
+**Cons:**
+- Re-implementing framework behavior is brittle
+
+**Effort:** Medium
+
+**Risk:** Medium
+
+## Recommended Action
+
+
+## Technical Details
+
+**Affected files:**
+- `lib/ruby_llm/skills.rb`
+
+## Resources
+
+- PR: https://github.com/kieranklaassen/ruby_llm-skills/pull/2
+- Reproduction command output from review session (`unknown keyword: :prefix`)
+
+## Acceptance Criteria
+
+- [x] Global monkey patch is removed or fully compatibility-scoped
+- [x] Non-Rails environment still loads `ruby_llm` agent path successfully
+- [x] Regression test/documentation for compatibility behavior exists
+
+## Work Log
+
+### 2026-02-17 - Code Review Finding
+
+**By:** Codex
+
+**Actions:**
+- Verified runtime behavior of new `delegate` shim
+- Confirmed incompatibility with common delegate keywords
+
+**Learnings:**
+- Small compatibility shims can create broad process-level side effects
+
+### 2026-02-17 - Resolution
+
+**By:** Codex
+
+**Actions:**
+- Reworked fallback `delegate` shim to support common keywords (`prefix`, `allow_nil`, `private`)
+- Kept shim gated to environments where `Module#delegate` is missing
+- Added delegate compatibility tests
+
+**Learnings:**
+- Compatibility shims need practical option support to avoid surprising failures in host apps

--- a/todos/005-complete-p2-agent-private-api-version-coupling.md
+++ b/todos/005-complete-p2-agent-private-api-version-coupling.md
@@ -1,0 +1,104 @@
+---
+status: complete
+priority: p2
+issue_id: "005"
+tags: [code-review, architecture, dependency, maintenance]
+dependencies: []
+---
+
+# Agent extension depends on private APIs with open-ended dependency
+
+The new extension prepends into `RubyLLM::Agent` private configuration internals but dependency constraint is `ruby_llm >= 1.12` with no upper bound.
+
+## Problem Statement
+
+Private API coupling plus open-ended version range increases risk of silent breakage when upstream internals change.
+
+## Findings
+
+- Uses singleton `prepend` to intercept private `apply_configuration` path.
+- Calls private helpers (`runtime_context`, `llm_chat_for`) directly.
+- Gemspec allows any future version above 1.12.
+- Evidence references:
+  - `lib/ruby_llm/skills/agent_extensions.rb:64`
+  - `lib/ruby_llm/skills/agent_extensions.rb:67`
+  - `lib/ruby_llm/skills/agent_extensions.rb:68`
+  - `ruby_llm-skills.gemspec:34`
+
+## Proposed Solutions
+
+### Option 1: Constrain to tested minor range (recommended)
+
+**Approach:** Pin to `~> 1.12` (or `< 1.13`) until compatibility is confirmed.
+
+**Pros:**
+- Prevents accidental upgrades to incompatible internals
+- Aligns with private API risk profile
+
+**Cons:**
+- Requires periodic dependency bump work
+
+**Effort:** Small
+
+**Risk:** Low
+
+---
+
+### Option 2: Add runtime compatibility checks + CI matrix
+
+**Approach:** Detect required methods/signatures at load time and raise clear errors; test against supported versions.
+
+**Pros:**
+- Better failure messaging
+- Supports broader version range safely
+
+**Cons:**
+- More maintenance and CI complexity
+
+**Effort:** Medium
+
+**Risk:** Low
+
+## Recommended Action
+
+
+## Technical Details
+
+**Affected files:**
+- `lib/ruby_llm/skills/agent_extensions.rb`
+- `ruby_llm-skills.gemspec`
+
+## Resources
+
+- PR: https://github.com/kieranklaassen/ruby_llm-skills/pull/2
+
+## Acceptance Criteria
+
+- [x] Dependency policy reflects private API coupling risk
+- [x] Compatibility checks/tests exist for supported ruby_llm range
+- [x] Failure mode is explicit when upstream contract changes
+
+## Work Log
+
+### 2026-02-17 - Code Review Finding
+
+**By:** Codex
+
+**Actions:**
+- Mapped extension call path to upstream private methods
+- Confirmed open-ended dependency declaration
+
+**Learnings:**
+- Private integration points need tighter version and compatibility controls
+
+### 2026-02-17 - Resolution
+
+**By:** Codex
+
+**Actions:**
+- Added required-agent-method compatibility checks during extension inclusion
+- Changed gem dependency from `>= 1.12` to `~> 1.12`
+- Re-ran full test and lint suites after dependency-policy update
+
+**Learnings:**
+- Private API hooks should pair with explicit version policy plus boot-time compatibility checks

--- a/todos/006-complete-p3-agent-with-skills-replace-semantics-doc-gap.md
+++ b/todos/006-complete-p3-agent-with-skills-replace-semantics-doc-gap.md
@@ -1,0 +1,104 @@
+---
+status: complete
+priority: p3
+issue_id: "006"
+tags: [code-review, docs, api, usability]
+dependencies: []
+---
+
+# Runtime with_skills replaces class skills but docs imply additive behavior
+
+`agent.with_skills("extra/skills")` replaces the existing `:skill` tool registration, while documentation text implies skills are being added.
+
+## Problem Statement
+
+Ambiguous API semantics can cause user confusion and hidden behavior changes in production agents.
+
+## Findings
+
+- `with_skills` delegates to chat and registers a `SkillTool` by name `:skill`.
+- `Chat#with_tool` stores by tool name key, so second registration overwrites first.
+- README example uses additive wording without explicit replace semantics.
+- Evidence references:
+  - `lib/ruby_llm/skills/agent_extensions.rb:55`
+  - `lib/ruby_llm/skills/chat_extensions.rb:34`
+  - `README.md:46`
+  - `README.md:47`
+
+## Proposed Solutions
+
+### Option 1: Clarify docs and method contract (recommended)
+
+**Approach:** Document replacement behavior explicitly and provide merging example in a single call.
+
+**Pros:**
+- Low effort
+- Prevents confusion immediately
+
+**Cons:**
+- Does not change behavior
+
+**Effort:** Small
+
+**Risk:** Low
+
+---
+
+### Option 2: Add explicit `append:`/`replace:` option
+
+**Approach:** Keep current default or switch default, but make semantics explicit in API.
+
+**Pros:**
+- Clearer runtime behavior
+- Better ergonomics for advanced usage
+
+**Cons:**
+- Additional API complexity
+
+**Effort:** Medium
+
+**Risk:** Low
+
+## Recommended Action
+
+
+## Technical Details
+
+**Affected files:**
+- `README.md`
+- `lib/ruby_llm/skills/agent_extensions.rb`
+- `lib/ruby_llm/skills/chat_extensions.rb`
+
+## Resources
+
+- PR: https://github.com/kieranklaassen/ruby_llm-skills/pull/2
+
+## Acceptance Criteria
+
+- [x] Docs clearly state replacement vs additive semantics
+- [x] Tests verify intended behavior for repeated `with_skills` calls
+- [x] If API changes, migration guidance is documented
+
+## Work Log
+
+### 2026-02-17 - Code Review Finding
+
+**By:** Codex
+
+**Actions:**
+- Traced tool registration path and overwrite behavior
+- Compared behavior with README wording
+
+**Learnings:**
+- Explicit API semantics reduce downstream integration bugs
+
+### 2026-02-17 - Resolution
+
+**By:** Codex
+
+**Actions:**
+- Added README note clarifying that `agent.with_skills` replaces current skill-tool configuration
+- Added regression test asserting replacement semantics
+
+**Learnings:**
+- Explicit docs and tests for overwrite behavior prevent ambiguous integration expectations


### PR DESCRIPTION
## Summary
- Add `RubyLLM::Skills::AgentExtensions` with class-level `skills` DSL support for `RubyLLM::Agent`
- Apply skills during agent configuration for both `.chat` and `.new` entry points
- Add instance-level `with_skills` for runtime skill configuration on agent instances
- Bump `ruby_llm` dependency to `>= 1.12` and update lockfile to 1.12.0
- Add unit and integration tests for agent skills behavior
- Document Agent usage in README
- Add a minimal `delegate` fallback for plain Ruby runtime compatibility with `ruby_llm` 1.12.0 Agent

## Testing
- `bundle exec ruby -Itest test/ruby_llm/skills/test_agent_extensions.rb`
- `bundle exec ruby -Itest test/ruby_llm/skills/test_agent_integration.rb`
- `bundle exec rake test`
- `bundle exec rake standard`

## Before / After Screenshots
No UI changes.

## Figma Design
Not applicable.

---

[![Compound Engineered](https://prompts:img.shields.io/badge/Compound-Engineered-6366f1)](https://prompts:github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with Codex